### PR TITLE
Issue #92: Enforce structural type constraint of 'reflect_value' via requires clause

### DIFF
--- a/clang/lib/AST/StmtPrinter.cpp
+++ b/clang/lib/AST/StmtPrinter.cpp
@@ -2646,7 +2646,7 @@ void StmtPrinter::VisitCXXReflectExpr(CXXReflectExpr *S) {
 
 void StmtPrinter::VisitCXXMetafunctionExpr(CXXMetafunctionExpr *S) {
   OS << "__metafunction(";
-  for (unsigned I = 0; I < S->getNumArgs(); ++S) {
+  for (unsigned I = 0; I < S->getNumArgs(); ++I) {
     PrintExpr(S->getArg(I));
     if (I + 1 != S->getNumArgs())
       OS << ", ";

--- a/clang/lib/Sema/Metafunctions.cpp
+++ b/clang/lib/Sema/Metafunctions.cpp
@@ -74,6 +74,10 @@ static bool get_next_member_decl_of(APValue &Result, Sema &S, EvalFn Evaluator,
                                     DiagFn Diagnoser, QualType ResultTy,
                                     SourceRange Range, ArrayRef<Expr *> Args);
 
+static bool is_structural_type(APValue &Result, Sema &S, EvalFn Evaluator,
+                               DiagFn Diagnoser, QualType ResultTy,
+                               SourceRange Range, ArrayRef<Expr *> Args);
+
 static bool map_decl_to_entity(APValue &Result, Sema &S, EvalFn Evaluator,
                                DiagFn Diagnoser, QualType ResultTy,
                                SourceRange Range, ArrayRef<Expr *> Args);
@@ -498,6 +502,7 @@ static constexpr Metafunction Metafunctions[] = {
   { Metafunction::MFRK_metaInfo, 3, 3, get_ith_template_argument_of },
   { Metafunction::MFRK_metaInfo, 2, 2, get_begin_member_decl_of },
   { Metafunction::MFRK_metaInfo, 2, 2, get_next_member_decl_of },
+  { Metafunction::MFRK_bool, 1, 1, is_structural_type },
   { Metafunction::MFRK_metaInfo, 1, 1, map_decl_to_entity },
 
   // exposed metafunctions
@@ -1682,6 +1687,27 @@ bool get_next_member_decl_of(APValue &Result, Sema &S, EvalFn Evaluator,
   if (Decl *Next = findIterableMember(S.Context, RV.getReflectedDecl(), false))
     return SetAndSucceed(Result, APValue(ReflectionKind::Declaration, Next));
   return SetAndSucceed(Result, Sentinel);
+}
+
+static bool is_structural_type(APValue &Result, Sema &S, EvalFn Evaluator,
+                               DiagFn Diagnoser, QualType ResultTy,
+                               SourceRange Range, ArrayRef<Expr *> Args) {
+  assert(Args[0]->getType()->isReflectionType());
+  assert(ResultTy == S.Context.BoolTy);
+  
+  APValue RV;
+  if (!Evaluator(RV, Args[0], true))
+    return true;
+  
+  auto result = false;
+  if (RV.isReflectedType()) {
+    const QualType QT = RV.getReflectedType();
+    const Type* T = QT.getTypePtr();
+
+    result = T->isStructuralType();
+  }
+
+  return SetAndSucceed(Result, makeBool(S.Context, result));
 }
 
 bool map_decl_to_entity(APValue &Result, Sema &S, EvalFn Evaluator,

--- a/libcxx/include/experimental/meta
+++ b/libcxx/include/experimental/meta
@@ -420,6 +420,7 @@ enum : unsigned {
   __metafn_get_ith_template_argument_of,
   __metafn_get_begin_member_decl_of,
   __metafn_get_next_member_decl_of,
+  __metafn_is_structural_type,
   __metafn_map_decl_to_entity,
 
   // exposed metafunctions
@@ -1320,7 +1321,9 @@ consteval auto is_user_provided(info r) -> bool {
 }
 
 // Returns a reflection of the value held by the provided argument.
-template <typename T> requires (!is_reference_v<T>)
+template <typename T> 
+  requires (!is_reference_v<T> && 
+            __metafunction(detail::__metafn_is_structural_type, LIFT(T)))
 consteval auto reflect_value(T r) -> info {
   constexpr info Ty = type_of(LIFT(r));
 

--- a/libcxx/test/std/experimental/reflection/to-and-from-values.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/to-and-from-values.pass.cpp
@@ -320,11 +320,9 @@ static_assert([:rvfirst:].first == 1);
 
 namespace reflect_value_callable {
 
-using std::meta::reflect_value;
-
 template<typename T>
 constexpr auto reflectValueCallable = 
-  requires { reflect_value<T>(std::declval<T>()); };
+  requires { std::meta::reflect_value<T>(std::declval<T>()); };
 
 enum class E {};
 

--- a/libcxx/test/std/experimental/reflection/to-and-from-values.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/to-and-from-values.pass.cpp
@@ -314,6 +314,60 @@ static_assert(rvfirst == std::meta::reflect_value(std::make_pair(1, true)));
 static_assert([:rvfirst:].first == 1);
 }  // namespace values_from_objects
 
+
+                           // ======================
+                           // reflect_value_callable
+                           // ======================
+
+namespace reflect_value_callable {
+
+using std::meta::reflect_value;
+
+template<typename T>
+constexpr auto reflectValueCallable = 
+  requires { reflect_value<T>(std::declval<T>()); };
+
+enum class E {};
+
+struct StructuralTypeClass {
+  int x;
+};
+
+struct NonStructuralTypeClass {
+  mutable int x;
+};
+
+struct NonStructuralTypeClass2 {
+  int f() { return x; };
+private:
+  int x;
+};
+
+// scalar types are allowed
+static_assert(reflectValueCallable<int>);
+static_assert(reflectValueCallable<const int>);
+static_assert(reflectValueCallable<const volatile int>);
+static_assert(reflectValueCallable<int*>);
+static_assert(reflectValueCallable<const int*>);
+static_assert(reflectValueCallable<const int* const>);
+static_assert(reflectValueCallable<E>);
+static_assert(reflectValueCallable<int StructuralTypeClass::*>);
+static_assert(reflectValueCallable<std::nullptr_t>);
+
+// literal class type with all non-static member vars public & non-mutable
+static_assert(reflectValueCallable<StructuralTypeClass>);
+
+// references are not allowed
+static_assert(!reflectValueCallable<int&>);
+static_assert(!reflectValueCallable<const int&>);
+static_assert(!reflectValueCallable<int&&>);
+static_assert(!reflectValueCallable<const int&&>);
+
+// non structural class types
+static_assert(!reflectValueCallable<NonStructuralTypeClass>);
+static_assert(!reflectValueCallable<NonStructuralTypeClass2>);
+}  // namespace reflect_value_callable
+
 // ========================
 // pointer_object_ambiguity
 // ========================

--- a/libcxx/test/std/experimental/reflection/to-and-from-values.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/to-and-from-values.pass.cpp
@@ -314,7 +314,6 @@ static_assert(rvfirst == std::meta::reflect_value(std::make_pair(1, true)));
 static_assert([:rvfirst:].first == 1);
 }  // namespace values_from_objects
 
-
                            // ======================
                            // reflect_value_callable
                            // ======================


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #92*

**Describe your changes**
* Implemented `is_structural_type `metafunction without exposing it through `std`
* Added it to the requires clause of `reflect_value`
* Fixed crash in `StmtPrinter::VisitCXXMetafunctionExpr`: the for loop was incrementing a pointer instead of an index variable

**Testing performed**
Added a few `static_assert`s that test if `reflect_value `can be instantiated with a given type.
