### PR TITLE
Mark CXX26Annotation as internal

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -997,7 +997,7 @@ public:
 
   let HasCustomParsing = 1;
   let TemplateDependent = 1;
-  let Documentation = [Undocumented];
+  let Documentation = [InternalOnly];
 }
 
 def ARMInterrupt : InheritableAttr, TargetSpecificAttr<TargetARM> {


### PR DESCRIPTION
Otherwise documentation generation fails due to missing any spellings:
```
llvm/clang/docs/../include/clang/Basic/Attr.td:962:5: error: Attribute has no supported spellings; cannot be documented
def CXX26Annotation : InheritableParamAttr {
    ^
```