### PR TITLE
Amend clang::Stmt bitflag setup to the "empty" CXXSpliceExpr ctor

### DIFF
--- a/clang/lib/AST/ExprCXX.cpp
+++ b/clang/lib/AST/ExprCXX.cpp
@@ -2034,6 +2034,7 @@ CXXSpliceExpr::CXXSpliceExpr(QualType ResultTy, ExprValueKind ValueKind,
 
 CXXSpliceExpr::CXXSpliceExpr(EmptyShell Empty)
   : Expr(CXXSpliceExprClass, Empty) {
+  SpliceExprBits.HasTemplateKWAndArgsInfo = false;
 }
 
 CXXSpliceExpr *CXXSpliceExpr::Create(ASTContext &C,


### PR DESCRIPTION
Before only the first eight bits were set.

Fixes issue 104.
