### PR TITLE
Add more tests for diagnostic messages

### DIFF
--- a/libcxx/test/std/experimental/reflection/names.verify.cpp
+++ b/libcxx/test/std/experimental/reflection/names.verify.cpp
@@ -1,0 +1,90 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright 2024 Bloomberg Finance L.P.
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03 || c++11 || c++14 || c++17 || c++20
+// ADDITIONAL_COMPILE_FLAGS: -freflection
+// ADDITIONAL_COMPILE_FLAGS: -freflection-new-syntax
+// ADDITIONAL_COMPILE_FLAGS: -fparameter-reflection
+// ADDITIONAL_COMPILE_FLAGS: -Wno-unneeded-internal-declaration -Wno-unused-variable -Wno-unused-value
+
+// <experimental/reflection>
+//
+// [reflection]
+
+#include <experimental/meta>
+
+struct A {
+  constexpr A([[maybe_unused]] int _a) {}
+
+  constexpr ~A() {}
+
+  consteval A operator+(int num) const { return A(num); }
+
+  template <typename T>
+  consteval static void foo() {}
+
+  operator int() const { return 42; }
+
+  template <typename T>
+  operator double() const {
+    return 42.0f;
+  }
+
+  template <typename T>
+  void operator()([[maybe_unused]] T lhs, [[maybe_unused]] T rhs) {}
+};
+
+int main() {
+            // ======================
+            // identifier_of
+            // ======================
+  int var;
+  identifier_of(^^var); // ok
+
+  identifier_of(^^int);
+  // expected-error@-1 {{call to consteval function 'std::meta::identifier_of' is not a constant expression}}
+  // expected-note-re@-2 {{reflected {{.*}} is anonymous and has no associated identifier}}
+
+  identifier_of(^^A::foo<int>);
+  // expected-error@-1 {{call to consteval function 'std::meta::identifier_of' is not a constant expression}}
+  // expected-note@-2 {{names of template specializations are not identifiers}}
+
+  /* TODO: clarify if test with constructor should fail or not
+  identifier_of(^^A::A);
+  // {{call to consteval function 'std::meta::identifier_of' is not a constant expression}}
+  // {{names of constructors are not identifiers}}
+  */
+
+  identifier_of(^^A::~A);
+  // expected-error@-1 {{call to consteval function 'std::meta::identifier_of' is not a constant expression}}
+  // expected-note@-2 {{names of destructors are not identifiers}}
+
+  identifier_of(^^A::operator+);
+  // expected-error@-1 {{call to consteval function 'std::meta::identifier_of' is not a constant expression}}
+  // expected-note@-2 {{names of operators are not identifiers}}
+
+  identifier_of(^^A::operator int);
+  // expected-error@-1 {{call to consteval function 'std::meta::identifier_of' is not a constant expression}}
+  // expected-note@-2 {{names of conversion functions are not identifiers}}
+
+  // todo: come up with test for constructor template
+
+  identifier_of(^^A::operator());
+  // expected-error@-1 {{call to consteval function 'std::meta::identifier_of' is not a constant expression}}
+  // expected-note@-2 {{names of operator templates are not identifiers}}
+
+  identifier_of(^^A::operator double);
+  // expected-error@-1 {{call to consteval function 'std::meta::identifier_of' is not a constant expression}}
+  // expected-note@-2 {{names of conversion function templates are not identifiers}}
+
+  identifier_of(^^::);
+  // expected-error@-1 {{call to consteval function 'std::meta::identifier_of' is not a constant expression}}
+  // expected-note@-2 {{the global namespace has no associated identifier}}
+}

--- a/libcxx/test/std/experimental/reflection/related-reflections.verify.cpp
+++ b/libcxx/test/std/experimental/reflection/related-reflections.verify.cpp
@@ -82,12 +82,10 @@ int main() {
   // expected-error@-1 {{call to consteval function 'std::meta::parent_of' is not a constant expression}}
   // expected-note-re@-2 {{{{.*}} has no parent}}
 
-  /* TODO: check if this is a bug
-  constexpr B obj{};
-  std::meta::parent_of(^^obj);
-  // {{call to consteval function 'std::meta::parent_of' is not a constant expression}}
-  // {{{{.*}} has no parent}}
-  */
+  constexpr int b = 1;
+  std::meta::parent_of(object_of(^^b));
+  // expected-error@-1 {{call to consteval function 'std::meta::parent_of' is not a constant expression}}
+  // expected-note-re@-2 {{{{.*}} has no parent}}
 
   std::meta::parent_of(^^int);
   // expected-error@-1 {{call to consteval function 'std::meta::parent_of' is not a constant expression}}

--- a/libcxx/test/std/experimental/reflection/related-reflections.verify.cpp
+++ b/libcxx/test/std/experimental/reflection/related-reflections.verify.cpp
@@ -22,6 +22,10 @@
 template <typename T>
 class A {};
 
+int foo() {
+  return 42;
+}
+
 struct B {
   constexpr B() {}
 
@@ -31,12 +35,16 @@ struct B {
 };
 
 int main() {
-  // operator_of
+                  // ==============
+                  // operator_of
+                  // ==============
   std::meta::operator_of(^^int);
   // expected-error@-1 {{call to consteval function 'std::meta::operator_of' is not a constant expression}}
   // expected-note-re@-2 {{{{.*}} is not an operator or operator template}}
 
-  // type_of
+                  // ==============
+                  // type_of
+                  // ==============
   constexpr int a = 3;
   std::meta::type_of(^^a); // ok
 
@@ -61,7 +69,9 @@ int main() {
   // expected-error@-1 {{call to consteval function 'std::meta::type_of' is not a constant expression}}
   // expected-note-re@-2 {{cannot query the type of {{.*}}}}
 
-  // parent_of
+                  // ==============
+                  // parent_of
+                  // ==============
   parent_of(^^B::InnerCls); // ok
 
   std::meta::parent_of(^^::);
@@ -82,14 +92,16 @@ int main() {
   std::meta::parent_of(^^int);
   // expected-error@-1 {{call to consteval function 'std::meta::parent_of' is not a constant expression}}
 
-  // template_of
+                  // ==============
+                  // template_of
+                  // ==============
   template_of(^^A<int>); // ok
 
   template_of(^^B);
   // expected-error@-1 {{call to consteval function 'std::meta::template_of' is not a constant expression}}
   // expected-note@-2 {{expected a reflection of a template specialization}}
 
-  template_of(^^B::~B);
+  template_of(^^foo);
   // expected-error@-1 {{call to consteval function 'std::meta::template_of' is not a constant expression}}
   // expected-note@-2 {{expected a reflection of a template specialization}}
 

--- a/libcxx/test/std/experimental/reflection/related-reflections.verify.cpp
+++ b/libcxx/test/std/experimental/reflection/related-reflections.verify.cpp
@@ -1,0 +1,103 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright 2024 Bloomberg Finance L.P.
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03 || c++11 || c++14 || c++17 || c++20
+// ADDITIONAL_COMPILE_FLAGS: -freflection -freflection-new-syntax
+// ADDITIONAL_COMPILE_FLAGS: -Wno-unused-variable -Wno-unused-value
+
+// <experimental/reflection>
+//
+// [reflection]
+
+#include <experimental/meta>
+#include <utility>
+
+template <typename T>
+class A {};
+
+struct B {
+  constexpr B() {}
+
+  constexpr ~B() {}
+
+  struct InnerCls {};
+};
+
+int main() {
+  // operator_of
+  std::meta::operator_of(^^int);
+  // expected-error@-1 {{call to consteval function 'std::meta::operator_of' is not a constant expression}}
+  // expected-note-re@-2 {{{{.*}} is not an operator or operator template}}
+
+  // type_of
+  constexpr int a = 3;
+  std::meta::type_of(^^a); // ok
+
+  std::meta::type_of(^^int);
+  // expected-error@-1 {{call to consteval function 'std::meta::type_of' is not a constant expression}}
+  // expected-note-re@-2 {{{{.*}} has no type}}
+
+  std::meta::type_of(^^::);
+  // expected-error@-1 {{call to consteval function 'std::meta::type_of' is not a constant expression}}
+  // expected-note-re@-2 {{{{.*}} has no type}}
+
+  std::meta::type_of(^^A<int>);
+  // expected-error@-1 {{call to consteval function 'std::meta::type_of' is not a constant expression}}
+  // expected-note-re@-2 {{{{.*}} has no type}}
+
+  const auto [x, y] = std::pair{1, 2};
+  std::meta::type_of(^^x);
+  // expected-error@-1 {{call to consteval function 'std::meta::type_of' is not a constant expression}}
+  // expected-note-re@-2 {{cannot query the type of {{.*}}}}
+
+  std::meta::type_of(^^B::~B);
+  // expected-error@-1 {{call to consteval function 'std::meta::type_of' is not a constant expression}}
+  // expected-note-re@-2 {{cannot query the type of {{.*}}}}
+
+  // parent_of
+  parent_of(^^B::InnerCls); // ok
+
+  std::meta::parent_of(^^::);
+  // expected-error@-1 {{call to consteval function 'std::meta::parent_of' is not a constant expression}}
+  // expected-note-re@-2 {{{{.*}} has no parent}}
+
+  std::meta::parent_of(std::meta::reflect_value(42));
+  // expected-error@-1 {{call to consteval function 'std::meta::parent_of' is not a constant expression}}
+  // expected-note-re@-2 {{{{.*}} has no parent}}
+
+  /* TODO: check if this is a bug
+  constexpr B obj{};
+  std::meta::parent_of(^^obj);
+  // {{call to consteval function 'std::meta::parent_of' is not a constant expression}}
+  // {{{{.*}} has no parent}}
+  */
+
+  std::meta::parent_of(^^int);
+  // expected-error@-1 {{call to consteval function 'std::meta::parent_of' is not a constant expression}}
+
+  // template_of
+  template_of(^^A<int>); // ok
+
+  template_of(^^B);
+  // expected-error@-1 {{call to consteval function 'std::meta::template_of' is not a constant expression}}
+  // expected-note@-2 {{expected a reflection of a template specialization}}
+
+  template_of(^^B::~B);
+  // expected-error@-1 {{call to consteval function 'std::meta::template_of' is not a constant expression}}
+  // expected-note@-2 {{expected a reflection of a template specialization}}
+
+  template_of(^^int);
+  // expected-error@-1 {{call to consteval function 'std::meta::template_of' is not a constant expression}}
+  // expected-note@-2 {{expected a reflection of a template specialization}}
+
+  template_of(^^::);
+  // expected-error@-1 {{call to consteval function 'std::meta::template_of' is not a constant expression}}
+  // expected-note@-2 {{expected a reflection of a template specialization}}
+}

--- a/libcxx/test/std/experimental/reflection/substitute.verify.cpp
+++ b/libcxx/test/std/experimental/reflection/substitute.verify.cpp
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright 2024 Bloomberg Finance L.P.
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03 || c++11 || c++14 || c++17 || c++20
+// ADDITIONAL_COMPILE_FLAGS: -freflection -freflection-new-syntax
+// ADDITIONAL_COMPILE_FLAGS: -Wno-unused-variable -Wno-unused-value
+
+// <experimental/reflection>
+//
+// [reflection]
+
+#include <experimental/meta>
+#include <vector>
+
+int main() {
+  can_substitute(^^std::vector, {^^int}); //ok
+  substitute(^^std::vector, {^^int}); //ok
+
+  can_substitute(^^int, {^^int});
+  // expected-error-re@-1 {{call to consteval function 'std::meta::can_substitute<{{.*}}>' is not a constant expression}}
+  // expected-note-re@-2 {{expected a reflection of a template, but got {{.*}}}}
+
+  substitute(^^int, {^^int});
+  // expected-error-re@-1 {{call to consteval function 'std::meta::substitute<{{.*}}>' is not a constant expression}}
+  // expected-note-re@-2 {{expected a reflection of a template, but got {{.*}}}}
+
+  substitute(^^std::vector, {^^::});
+  // expected-error-re@-1 {{call to consteval function 'std::meta::substitute<{{.*}}>' is not a constant expression}}
+  // expected-note-re@-2 {{a reflection of {{.*}} cannot represent a template argument}}
+}

--- a/libcxx/test/std/experimental/reflection/to-and-from-values.verify.cpp
+++ b/libcxx/test/std/experimental/reflection/to-and-from-values.verify.cpp
@@ -1,0 +1,80 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright 2024 Bloomberg Finance L.P.
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03 || c++11 || c++14 || c++17 || c++20
+// ADDITIONAL_COMPILE_FLAGS: -freflection -freflection-new-syntax
+// ADDITIONAL_COMPILE_FLAGS: -Wno-unused-variable -Wno-unused-value
+
+// <experimental/reflection>
+//
+// [reflection]
+
+#include <experimental/meta>
+
+class A {
+public:
+  consteval int get_a() const {
+    return a;
+  }
+private:
+  const int a = 42;
+};
+
+int main() {
+  constexpr int i = 1;
+  int non_constexpr_i = 42;
+  constexpr A obj{};
+
+              // ==============
+              // value_of
+              // ==============
+  value_of(^^i); // ok
+
+  value_of(^^non_constexpr_i);
+  // expected-error@-1 {{call to consteval function 'std::meta::value_of' is not a constant expression}}
+  // expected-note@-2 {{cannot query the value of a variable not usable in constant expressions}}
+
+  value_of(object_of(^^obj));
+  // expected-error@-1 {{call to consteval function 'std::meta::value_of' is not a constant expression}}
+  // expected-note@-2 {{cannot query the value of an object of non-structural type}}
+
+  value_of(^^A::get_a);
+  // expected-error@-1 {{call to consteval function 'std::meta::value_of' is not a constant expression}}
+  // expected-note-re@-2 {{cannot query the value of {{.*}}}}
+
+  value_of(^^int);
+  // expected-error@-1 {{call to consteval function 'std::meta::value_of' is not a constant expression}}
+  // expected-note-re@-2 {{cannot query the value of {{.*}}}}
+
+  value_of(^^::);
+  // expected-error@-1 {{call to consteval function 'std::meta::value_of' is not a constant expression}}
+  // expected-note-re@-2 {{cannot query the value of {{.*}}}}
+
+              // ==============
+              // object_of
+              // ==============
+  object_of(^^obj); // ok
+
+  object_of(^^A::get_a);
+  // expected-error@-1 {{call to consteval function 'std::meta::object_of' is not a constant expression}}
+  // expected-note-re@-2 {{cannot query the object of {{.*}}}}
+
+  object_of(^^int);
+  // expected-error@-1 {{call to consteval function 'std::meta::object_of' is not a constant expression}}
+  // expected-note-re@-2 {{cannot query the object of {{.*}}}}
+
+  object_of(std::meta::reflect_value(42));
+  // expected-error@-1 {{call to consteval function 'std::meta::object_of' is not a constant expression}}
+  // expected-note-re@-2 {{cannot query the object of {{.*}}}}
+
+  object_of(^^::);
+  // expected-error@-1 {{call to consteval function 'std::meta::object_of' is not a constant expression}}
+  // expected-note-re@-2 {{cannot query the object of {{.*}}}}
+}

--- a/libcxx/test/std/experimental/reflection/to-and-from-values.verify.cpp
+++ b/libcxx/test/std/experimental/reflection/to-and-from-values.verify.cpp
@@ -17,6 +17,7 @@
 // [reflection]
 
 #include <experimental/meta>
+#include <utility>
 
 class A {
 public:
@@ -26,6 +27,8 @@ public:
 private:
   const int a = 42;
 };
+
+enum Enum { Value = 42 };
 
 int main() {
   constexpr int i = 1;
@@ -77,4 +80,30 @@ int main() {
   object_of(^^::);
   // expected-error@-1 {{call to consteval function 'std::meta::object_of' is not a constant expression}}
   // expected-note-re@-2 {{cannot query the object of {{.*}}}}
+
+              // ==============
+              // extract
+              // ==============
+  extract<int>(^^i); // ok
+
+  extract<A>(^^i);
+  // expected-error@-1 {{call to consteval function 'std::meta::extract<A>' is not a constant expression}}
+  // expected-note-re@-2 {{reflected value of type {{.*}} cannot be extracted as a value of type {{.*}}}}}
+
+  const auto [x, y] = std::pair{1, 2};
+  extract<int>(^^x);
+  // expected-error@-1 {{call to consteval function 'std::meta::extract<int>' is not a constant expression}}
+  // expected-note@-2 {{extraction from a reflection of a structured binding is not allowed}}
+
+  extract<int>(^^::);
+  // expected-error@-1 {{call to consteval function 'std::meta::extract<int>' is not a constant expression}}
+  // expected-note-re@-2 {{cannot extract a value from a reflection of {{.*}}}}
+
+  extract<int>(object_of(^^obj));
+  // expected-error@-1 {{call to consteval function 'std::meta::extract<int>' is not a constant expression}}
+  // expected-note-re@-2 {{reflected object of type {{.*}} cannot be extracted as a value of type {{.*}}}}}
+
+  extract<A>(^^Enum::Value);
+  // expected-error@-1 {{call to consteval function 'std::meta::extract<A>' is not a constant expression}}
+  // expected-note-re@-2 {{reflected enum constant of type {{.*}} cannot be extracted as a value of type {{.*}}}}}
 }


### PR DESCRIPTION
**Describe your changes**

My PR adds very straightforward tests to trigger complilation errors with diagnostic notes. I didn't cover all library function and all error branches.  But hopefully these basic tests could be helpul for future testing of library functions.

Covered functions:
- `reflect_invoke`
- `identifier_of`
- `template_of`
- `type_of`
- `parent_of`
- `operator_of`
- `value_of`
- `object_of`
- `extract`
- `can_substitute`
- `substitute`

I tried to follow test files pattern so for related `*.pass.cpp` I added `*.verify.cpp` files with validation of compilation error diagnostic.

**Additional context**

Found at least 1 bug:
Code below doesn't produce an error and prints `A`. But in source code of function `identifier_of` I see that we should error on this condition with note `names of constructors are not identifiers`

Maybe I am missing something...

```cpp
#include <experimental/meta>
#include <iostream>


struct A {
  constexpr A() {}
};

int main() {
    std::cout << std::meta::identifier_of(^^A::A);
    // expected: names of constructors are not identifiers
    return 0;
}
```
