### PR TITLE
`define_aggregate`: provide empty user-defined constructor or destructor for unions with non-trivial members

### DIFF
--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -4539,8 +4539,7 @@ bool define_aggregate(APValue &Result, ASTContext &C, MetaActions &Meta,
       if (CD->isDefaultConstructor() && CD->isDeleted()) {
         CD->setDeletedAsWritten(false);
 
-        auto *EmptyBody = CompoundStmt::Create(
-            C, {}, FPOptionsOverride(), CD->getBeginLoc(), CD->getEndLoc());
+        auto *EmptyBody = CompoundStmt::CreateEmpty(C, 0, false);
         CD->setBody(EmptyBody);
         CD->setAccess(AS_public);
       }
@@ -4550,8 +4549,7 @@ bool define_aggregate(APValue &Result, ASTContext &C, MetaActions &Meta,
       if (DD->isDeleted()) {
         DD->setDeletedAsWritten(false);
 
-        auto *EmptyBody = CompoundStmt::Create(
-            C, {}, FPOptionsOverride(), DD->getBeginLoc(), DD->getEndLoc());
+        auto *EmptyBody = CompoundStmt::CreateEmpty(C, 0, false);
         DD->setBody(EmptyBody);
         DD->setAccess(AS_public);
       }

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -4532,6 +4532,24 @@ bool define_aggregate(APValue &Result, ASTContext &C, MetaActions &Meta,
   if (!Definition)
     return true;
 
+  if (Definition->isUnion()) {
+    // union specific behaviour of "define_aggregate"
+
+    for (CXXConstructorDecl *CD : Definition->ctors()) {
+      if (CD->isDefaultConstructor() && CD->isDeleted()) {
+        CD->setDeletedAsWritten(false);
+        CD->setExplicitlyDefaulted(true);
+      }
+    }
+
+    if (CXXDestructorDecl *DD = Definition->getDestructor()) {
+      if (DD->isDeleted()) {
+        DD->setDeletedAsWritten(false);
+        DD->setExplicitlyDefaulted(true);
+      }
+    }
+  }
+
   C.recordClassMemberSpecHash(ToComplete, MemberSpecHash);
   return SetAndSucceed(Result, makeReflection(ToComplete));
 }

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -4537,21 +4537,38 @@ bool define_aggregate(APValue &Result, ASTContext &C, MetaActions &Meta,
 
     for (CXXConstructorDecl *CD : Definition->ctors()) {
       if (CD->isDefaultConstructor() && CD->isDeleted()) {
-        CD->setDeletedAsWritten(false);
+        CXXConstructorDecl *CanonicalCD = CD->getCanonicalDecl();
 
-        auto *EmptyBody = CompoundStmt::CreateEmpty(C, 0, false);
-        CD->setBody(EmptyBody);
-        CD->setAccess(AS_public);
+        CanonicalCD->setImplicit(false);
+        CanonicalCD->setDeletedAsWritten(false);
+        CanonicalCD->setDefaulted(false);
+        CanonicalCD->setAccess(AS_public);
+
+        auto *EmptyBody =
+            CompoundStmt::CreateEmpty(CanonicalCD->getASTContext(), 0, false);
+        CanonicalCD->setBody(EmptyBody);
+
+        assert(CD->isUserProvided());
+        assert(CD->isDefaultConstructor());
+        assert(!CD->isDeleted());
       }
     }
 
     if (CXXDestructorDecl *DD = Definition->getDestructor()) {
       if (DD->isDeleted()) {
-        DD->setDeletedAsWritten(false);
+        CXXDestructorDecl *CanonicalDD = DD->getCanonicalDecl();
 
-        auto *EmptyBody = CompoundStmt::CreateEmpty(C, 0, false);
-        DD->setBody(EmptyBody);
-        DD->setAccess(AS_public);
+        CanonicalDD->setImplicit(false);
+        CanonicalDD->setDeletedAsWritten(false);
+        CanonicalDD->setDefaulted(false);
+        CanonicalDD->setAccess(AS_public);
+
+        auto *EmptyBody =
+            CompoundStmt::CreateEmpty(CanonicalDD->getASTContext(), 0, false);
+        CanonicalDD->setBody(EmptyBody);
+
+        assert(DD->isUserProvided());
+        assert(!DD->isDeleted());
       }
     }
   }

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -4538,14 +4538,22 @@ bool define_aggregate(APValue &Result, ASTContext &C, MetaActions &Meta,
     for (CXXConstructorDecl *CD : Definition->ctors()) {
       if (CD->isDefaultConstructor() && CD->isDeleted()) {
         CD->setDeletedAsWritten(false);
-        CD->setExplicitlyDefaulted(true);
+
+        auto *EmptyBody = CompoundStmt::Create(
+            C, {}, FPOptionsOverride(), CD->getBeginLoc(), CD->getEndLoc());
+        CD->setBody(EmptyBody);
+        CD->setAccess(AS_public);
       }
     }
 
     if (CXXDestructorDecl *DD = Definition->getDestructor()) {
       if (DD->isDeleted()) {
         DD->setDeletedAsWritten(false);
-        DD->setExplicitlyDefaulted(true);
+
+        auto *EmptyBody = CompoundStmt::Create(
+            C, {}, FPOptionsOverride(), DD->getBeginLoc(), DD->getEndLoc());
+        DD->setBody(EmptyBody);
+        DD->setAccess(AS_public);
       }
     }
   }

--- a/libcxx/test/std/experimental/reflection/define-aggregate.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/define-aggregate.pass.cpp
@@ -349,5 +349,4 @@ static_assert(std::is_trivially_destructible<UU>::value == false);
 
 } // namespace non_trivial_constructor_and_destructor
 
-int main() {
-}
+int main() {}

--- a/libcxx/test/std/experimental/reflection/define-aggregate.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/define-aggregate.pass.cpp
@@ -324,8 +324,8 @@ static_assert(is_type(define_aggregate(
         data_member_spec(^^A),
     })));
 
-static_assert(std::is_trivially_constructible_v<U> == true);
-static_assert(std::is_trivially_destructible_v<U> == true);
+static_assert(std::is_default_constructible_v<U> == true);
+static_assert(std::is_destructible<U>::value == true);
 } // namespace non_trivial_constructor_and_destructor
 
 int main() { }

--- a/libcxx/test/std/experimental/reflection/define-aggregate.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/define-aggregate.pass.cpp
@@ -304,7 +304,7 @@ static_assert(is_type(define_aggregate(^^S2, {
 
 }  // namespace repeat_calls
 
-namespace non_trivial_constructor_and_destructor {
+namespace non_trivial_constructor_and_destructor_of_union_members {
 // https://github.com/bloomberg/clang-p2996/issues/115
 
 // all members of union are trivially constructible and destructible
@@ -322,7 +322,7 @@ static_assert(std::is_trivially_constructible<U>::value == true);
 static_assert(std::is_destructible<U>::value == true);
 static_assert(std::is_trivially_destructible<U>::value == true);
 
-// at least one member of union has non-trivial constructor and destructor
+// at least one member of union has non-trivial constructor or destructor
 struct A {
   constexpr A() {
     // no-op

--- a/libcxx/test/std/experimental/reflection/define-aggregate.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/define-aggregate.pass.cpp
@@ -306,15 +306,6 @@ static_assert(is_type(define_aggregate(^^S2, {
 
 namespace non_trivial_constructor_and_destructor {
 // https://github.com/bloomberg/clang-p2996/issues/115
-struct A {
-  constexpr A() {
-    // no-op
-  }
-
-  constexpr ~A() {
-    // no-op
-  }
-};
 
 // all members of union are trivially constructible and destructible
 union U;
@@ -332,6 +323,16 @@ static_assert(std::is_destructible<U>::value == true);
 static_assert(std::is_trivially_destructible<U>::value == true);
 
 // at least one member of union has non-trivial constructor and destructor
+struct A {
+  constexpr A() {
+    // no-op
+  }
+
+  constexpr ~A() {
+    // no-op
+  }
+};
+
 union UU;
 static_assert(is_type(define_aggregate(
     ^^UU,
@@ -349,6 +350,4 @@ static_assert(std::is_trivially_destructible<UU>::value == false);
 } // namespace non_trivial_constructor_and_destructor
 
 int main() {
-  non_trivial_constructor_and_destructor::UU u;
-  u.~UU();
 }

--- a/libcxx/test/std/experimental/reflection/define-aggregate.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/define-aggregate.pass.cpp
@@ -349,4 +349,4 @@ static_assert(std::is_trivially_destructible<UU>::value == false);
 
 } // namespace non_trivial_constructor_and_destructor
 
-int main() {}
+int main() { }

--- a/libcxx/test/std/experimental/reflection/define-aggregate.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/define-aggregate.pass.cpp
@@ -324,8 +324,14 @@ static_assert(is_type(define_aggregate(
         data_member_spec(^^A),
     })));
 
-static_assert(std::is_default_constructible_v<U> == true);
+static_assert(std::is_default_constructible<U>::value == true);
+static_assert(std::is_trivially_constructible<U>::value == false);
+
 static_assert(std::is_destructible<U>::value == true);
+static_assert(std::is_trivially_destructible<U>::value == false);
 } // namespace non_trivial_constructor_and_destructor
 
-int main() { }
+int main() {
+  non_trivial_constructor_and_destructor::U u{1};
+  u.~U();
+}

--- a/libcxx/test/std/experimental/reflection/define-aggregate.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/define-aggregate.pass.cpp
@@ -316,22 +316,39 @@ struct A {
   }
 };
 
+// all members of union are trivially constructible and destructible
 union U;
 static_assert(is_type(define_aggregate(
     ^^U,
     {
         data_member_spec(^^int),
-        data_member_spec(^^A),
+        data_member_spec(^^char),
     })));
 
 static_assert(std::is_default_constructible<U>::value == true);
-static_assert(std::is_trivially_constructible<U>::value == false);
+static_assert(std::is_trivially_constructible<U>::value == true);
 
 static_assert(std::is_destructible<U>::value == true);
-static_assert(std::is_trivially_destructible<U>::value == false);
+static_assert(std::is_trivially_destructible<U>::value == true);
+
+// at least one member of union has non-trivial constructor and destructor
+union UU;
+static_assert(is_type(define_aggregate(
+    ^^UU,
+    {
+        data_member_spec(^^int),
+        data_member_spec(^^A),
+    })));
+
+static_assert(std::is_default_constructible<UU>::value == true);
+static_assert(std::is_trivially_constructible<UU>::value == false);
+
+static_assert(std::is_destructible<UU>::value == true);
+static_assert(std::is_trivially_destructible<UU>::value == false);
+
 } // namespace non_trivial_constructor_and_destructor
 
 int main() {
-  non_trivial_constructor_and_destructor::U u{1};
-  u.~U();
+  non_trivial_constructor_and_destructor::UU u;
+  u.~UU();
 }

--- a/libcxx/test/std/experimental/reflection/define-aggregate.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/define-aggregate.pass.cpp
@@ -20,6 +20,7 @@
 //
 // RUN: %{exec} %t.exe > %t.stdout
 
+#include <type_traits>
 #include <experimental/meta>
 
 #include <print>
@@ -302,5 +303,29 @@ static_assert(is_type(define_aggregate(^^S2, {
 })));
 
 }  // namespace repeat_calls
+
+namespace non_trivial_constructor_and_destructor {
+// https://github.com/bloomberg/clang-p2996/issues/115
+struct A {
+  constexpr A() {
+    // no-op
+  }
+
+  constexpr ~A() {
+    // no-op
+  }
+};
+
+union U;
+static_assert(is_type(define_aggregate(
+    ^^U,
+    {
+        data_member_spec(^^int),
+        data_member_spec(^^A),
+    })));
+
+static_assert(std::is_trivially_constructible_v<U> == true);
+static_assert(std::is_trivially_destructible_v<U> == true);
+} // namespace non_trivial_constructor_and_destructor
 
 int main() { }


### PR DESCRIPTION
Issue number of the reported bug or feature request: #115 

**Describe your changes**

Tried to implement next behaviour from paper:
```
[7.10] If C is a union type for which any of its members are not trivially default constructible, then D has a user-provided default constructor which has no effect.

[7.11] If C is a union type for which any of its members are not trivially destructible, then D has a user-provided destructor which has no effect.  
```

**Testing performed**

- Automated testing with `type_traits`
- Manual testing via code like this
```cpp
union UU;
static_assert(is_type(define_aggregate(
    ^^UU,
    {
        data_member_spec(^^int),
        data_member_spec(^^std::string),
    })));

int main() {
  UU u;
  u.~UU();
  
  return 0;
}
```
- assertations in code

**Additional context**

N/A
