### PR TITLE
To use custom annotation it requires the type to be equality_comparable

### DIFF
--- a/libcxx/include/experimental/meta
+++ b/libcxx/include/experimental/meta
@@ -2203,7 +2203,7 @@ consteval auto annotations_of(info r, info ty) -> vector<info> {
 }
 
 template<typename T>
-consteval optional<T> annotation_of_type(info r) {
+consteval optional<T> annotation_of_type(info r) requires equality_comparable<T> {
   auto v = annotations_of(r, ^^T);
   optional<T> result{};
   for (info a: v) {


### PR DESCRIPTION
*Issue number of the reported bug or feature request:  p3394 usage

**Describe your changes**
When using a custom annotations and getting access to it with the function annotation_of_type<T> the T is required to be equality_comparable.
 
If not the compile error message leads down to missing operator != for the type

**Testing performed**
When testing with new annotations types clangd reports that T doesn't meet the requires clauses. The compile message is also cleaner as well.

``` c++
namespace lua {
struct rename {
  const char *name;
  
  auto operator<=>(const rename &) const = default;
};

struct Person
{
  [[=lua::rename("firstName")]] std::string first_name;
};

template<typename T>
consteval auto GetName() -> std::string_view {
    return
        std::meta::annotation_of_type<lua::rename>(^^T)
            .transform([](lua::rename rename) {
              return std::string_view(rename.name);
            })
            .value_or(std::meta::display_string_of(^^T));
}
```
