### PR TITLE
Fix empty template argument list rendering

### DIFF
--- a/libcxx/include/experimental/meta
+++ b/libcxx/include/experimental/meta
@@ -2607,6 +2607,9 @@ consteval auto pretty_printer<CharT>::render_template_argument_list_of()
       -> string_t {
   string_t result;
 
+  if (template_arguments_of(R).empty())
+    return string_constant("<>");
+
   size_t Idx = 0;
   [:expand(template_arguments_of(R)):] >> [&]<auto TArg> {
     result += (Idx++ < 1 ? string_constant("<") : string_constant(", "));


### PR DESCRIPTION
I noticed a small defect with the template argument list rendering performed by `display_string_of`. Consider the following example:
```cpp
#include <print>
#include <experimental/meta>

template <typename...>
struct Foo{};

int main() {
    std::println("{}", display_string_of(^^Foo<>));
}
```
This currently prints `Foo>`, the expected output however is `Foo<>`.


Since the patch is trivial, I went ahead and fixed it myself instead of opening an issue. I hope that's fine :)