### PR TITLE
Fixing alignment_of references members

### DIFF
--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -5344,13 +5344,12 @@ bool alignment_of(APValue &Result, ASTContext &C, MetaActions &Meta,
   }
   case ReflectionKind::Declaration: {
     const ValueDecl *VD = cast<ValueDecl>(RV.getReflectedDecl());
-    size_t Align = C.getTypeAlignInChars(VD->getType()).getQuantity();
 
     if (const FieldDecl *FD = dyn_cast<const FieldDecl>(VD)) {
       if (FD->isBitField())
         return true;
     }
-    Align = C.getDeclAlign(VD, true).getQuantity();
+    size_t Align = C.getDeclAlign(VD, false).getQuantity();
 
     return SetAndSucceed(Result,
                          APValue(C.MakeIntValue(Align, C.getSizeType())));

--- a/libcxx/test/std/experimental/reflection/layout.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/layout.pass.cpp
@@ -88,12 +88,14 @@ struct Align {
     alignas(8) char a8;
 
     alignas(16) int &r1;
+    int &r2;
 };
 static_assert(alignment_of(^^Align::a1) == 1);
 static_assert(alignment_of(^^Align::a2) == 2);
 static_assert(alignment_of(^^Align::a4) == 4);
 static_assert(alignment_of(^^Align::a8) == 8);
 static_assert(alignment_of(^^Align::r1) == 16);
+static_assert(alignment_of(^^Align::r2) == 8);
 static_assert(alignment_of(^^Align) == 16);
 static_assert(offset_of(^^Align::a1) == std::meta::member_offset{0, 0});
 static_assert(offset_of(^^Align::a2) == std::meta::member_offset{2, 0});


### PR DESCRIPTION
Currently we get `alignment_of(^^Align::r2) == 4)`. 