### PR TITLE
[P3074] Implementing part of trivial unions

### DIFF
--- a/clang/lib/AST/DeclCXX.cpp
+++ b/clang/lib/AST/DeclCXX.cpp
@@ -1217,6 +1217,9 @@ void CXXRecordDecl::addedMember(Decl *D) {
     // those because they are always unnamed.
     bool IsZeroSize = Field->isZeroSize(Context);
 
+    // P3074
+    const bool TrivialUnion = Context.getLangOpts().CPlusPlus26 && isUnion();
+
     if (const auto *RecordTy = T->getAs<RecordType>()) {
       auto *FieldRec = cast<CXXRecordDecl>(RecordTy->getDecl());
       if (FieldRec->getDefinition()) {
@@ -1278,7 +1281,8 @@ void CXXRecordDecl::addedMember(Decl *D) {
         //       class type (or array thereof), each such class has a trivial
         //       default constructor.
         if (!FieldRec->hasTrivialDefaultConstructor())
-          data().HasTrivialSpecialMembers &= ~SMF_DefaultConstructor;
+          if (!TrivialUnion)
+            data().HasTrivialSpecialMembers &= ~SMF_DefaultConstructor;
 
         // C++0x [class.copy]p13:
         //   A copy/move constructor for class X is trivial if [...]
@@ -1316,7 +1320,8 @@ void CXXRecordDecl::addedMember(Decl *D) {
           data().HasTrivialSpecialMembers &= ~SMF_MoveAssignment;
 
         if (!FieldRec->hasTrivialDestructor())
-          data().HasTrivialSpecialMembers &= ~SMF_Destructor;
+          if (!TrivialUnion)
+            data().HasTrivialSpecialMembers &= ~SMF_Destructor;
         if (!FieldRec->hasTrivialDestructorForCall())
           data().HasTrivialSpecialMembersForCall &= ~SMF_Destructor;
         if (!FieldRec->hasIrrelevantDestructor())

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -9538,6 +9538,13 @@ bool SpecialMemberDeletionInfo::shouldDeleteForSubobjectCall(
   CXXMethodDecl *Decl = SMOR.getMethod();
   FieldDecl *Field = Subobj.dyn_cast<FieldDecl*>();
 
+  // P3074: default ctor and dtor for unions are not deleted, regardless of whether
+  // the underlying fields have non-trivial or deleted versions of those members
+  if (this->S.Context.getLangOpts().CPlusPlus26)
+    if (Field && Field->getParent()->isUnion() && (CSM == CXXSpecialMemberKind::DefaultConstructor
+                                                || CSM == CXXSpecialMemberKind::Destructor))
+      return false;
+
   int DiagKind = -1;
 
   if (SMOR.getKind() == Sema::SpecialMemberOverloadResult::NoMemberOrDeleted)


### PR DESCRIPTION
[P3074](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3074r7.html) makes unions trivially destructible and default constructible in all contexts. We previously had a hack for `define_aggregate` to make it sort of do that, which isn't implemented, so this makes it so that it's possible to implement `variant`. 