### PR TITLE
fix is_reflection_type

### DIFF
--- a/libcxx/include/meta
+++ b/libcxx/include/meta
@@ -1504,7 +1504,7 @@ consteval auto is_function_type(info r) -> bool {
 }
 
 consteval auto is_reflection_type(info r) -> bool {
-  return r == ^^info;
+  return dealias(r) == dealias(^^info);
 }
 
 consteval auto is_reference_type(info r) -> bool {


### PR DESCRIPTION
`is_reflection_type` currently compares a reflection against the type alias `std::meta::info` instead of the aliased reflection type. We need to dealias it to check against the aliased type instead of the alias itself.

Consider the following example:
```cpp
static_assert(is_reflection_type(^^std::meta::info)); // passes, we are comparing aliases
static_assert(not is_reflection_type(type_of(reflect_constant(^^int)))); // oops
static_assert(not is_reflection_type(^^decltype(^^int))); // oops
```

Dealiasing both the reflection `r` and `std::meta::info` makes all these assertions pass as expected:
```cpp
consteval auto is_reflection_type(info r) -> bool {
  return dealias(r) == dealias(^^info);
}

// correct behavior: 
static_assert(is_reflection_type(^^std::meta::info));
static_assert(is_reflection_type(type_of(reflect_constant(^^int))));
static_assert(is_reflection_type(^^decltype(^^int)));
```
[Run on Compiler Explorer](https://godbolt.org/z/zqvrMa8z3)