### PR TITLE
Fixing is_structural_type

### DIFF
--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -2025,6 +2025,11 @@ bool is_structural_type(APValue &Result, ASTContext &C, MetaActions &Meta,
 
   auto result = false;
   if (RV.isReflectedType()) {
+    // If this is a declared type with a reachable definition, ensure that the
+    // type is instantiated.
+    if (Decl *typeDecl = findTypeDecl(RV.getReflectedType()))
+      Meta.EnsureInstantiated(typeDecl, Range);
+
     const QualType QT = RV.getReflectedType();
     const Type* T = QT.getTypePtr();
 

--- a/libcxx/include/meta
+++ b/libcxx/include/meta
@@ -1400,10 +1400,13 @@ consteval auto is_user_declared(info r) -> bool {
   return __metafunction(detail::__metafn_is_user_declared, r);
 }
 
+consteval auto is_structural_type(info r) -> bool {
+  return __metafunction(detail::__metafn_is_structural_type, r);
+}
+
 // Returns a reflection of the value held by the provided argument.
 template <typename T>
-  requires (!is_reference_v<T> &&
-            __metafunction(detail::__metafn_is_structural_type, ^^T))
+  requires (!is_reference_v<T> && is_structural_type(^^T))
 consteval auto reflect_constant(T r) -> info {
   return __metafunction(detail::__metafn_reflect_result, ^^T, r);
 }

--- a/libcxx/test/std/experimental/reflection/meta-type-traits.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/meta-type-traits.pass.cpp
@@ -225,4 +225,12 @@ using Var = std::variant<int, bool, char, int *>;
 static_assert(variant_size(^^Var) == 4);
 static_assert(variant_alternative(3, ^^Var) == ^^int *);
 
+ struct X { int x; };
+ struct Y { private: [[maybe_unused]] int x; };
+ template <class T> struct TCls { T t; };
+ static_assert(is_structural_type(^^X));
+ static_assert(!is_structural_type(^^Y));
+ static_assert(is_structural_type(^^TCls<X>));
+ static_assert(!is_structural_type(^^TCls<Y>));
+
 int main() { }


### PR DESCRIPTION
Fixes the `is_structural_type` intrinsic to actually work on templated types previously clang would crash on `is_structural_type(^^TCls<X>)`. I have no idea how we didn't run into this until my random testing last week, that's shocking to me. This appears to fix it. 