### PR TITLE
Adding string literal manipulation

### DIFF
--- a/clang/include/clang/AST/Metafunction.h
+++ b/clang/include/clang/AST/Metafunction.h
@@ -36,6 +36,7 @@ public:
     MFRK_sizeT,
     MFRK_sourceLoc,
     MFRK_spliceFromArg,
+    MFRK_charPtr,
   };
 
   using EvaluateFn = CXXMetafunctionExpr::EvaluateFn;

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -6460,8 +6460,7 @@ bool string_literal_from(APValue &Result, ASTContext &C, MetaActions &Meta,
     const Expr *BaseE = Base.dyn_cast<const Expr*>();
 
     if (llvm::isa_and_nonnull<StringLiteral>(BaseE)) {
-      ArrayRef<APValue::LValuePathEntry> EmptyPath{};
-      return SetAndSucceed(Result, APValue(Base, CharUnits::Zero(), EmptyPath, false, false));
+      return SetAndSucceed(Result, APValue(Base, CharUnits::Zero(), APValue::NoLValuePath(), false));
     }
     return SetAndSucceed(Result, APValue((const ValueDecl*)nullptr, CharUnits::Zero(), APValue::NoLValuePath(), true));
 }

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -711,6 +711,22 @@ static bool reflect_invoke(APValue &Result, ASTContext &C, MetaActions &Meta,
                            SourceRange Range, ArrayRef<Expr *> Args,
                            Decl *ContainingDecl);
 
+             // =================================
+             // P3491 string_literal manipulation
+             // =================================
+
+static bool is_string_literal(APValue &Result, ASTContext &C, MetaActions &Meta,
+                              EvalFn Evaluator, DiagFn Diagnoser,
+                              bool AllowInjection, QualType ResultTy,
+                              SourceRange Range, ArrayRef<Expr *> Args,
+                              Decl *ContainingDecl);
+
+static bool string_literal_from(APValue &Result, ASTContext &C, MetaActions &Meta,
+                                EvalFn Evaluator, DiagFn Diagnoser,
+                                bool AllowInjection, QualType ResultTy,
+                                SourceRange Range, ArrayRef<Expr *> Args,
+                                Decl *ContainingDecl);
+
 // -----------------------------------------------------------------------------
 // Metafunction table
 //
@@ -844,6 +860,10 @@ static constexpr Metafunction Metafunctions[] = {
   // Other bespoke functions (not proposed at this time)
   { Metafunction::MFRK_bool, 1, 1, is_access_specified },
   { Metafunction::MFRK_metaInfo, 5, 5, reflect_invoke },
+
+  // P3491 string literal manipulation
+  { Metafunction::MFRK_bool, 1, 1, is_string_literal },
+  { Metafunction::MFRK_charPtr, 1, 1, string_literal_from },
 };
 constexpr const unsigned NumMetafunctions = sizeof(Metafunctions) /
                                             sizeof(Metafunction);
@@ -6403,6 +6423,47 @@ bool reflect_invoke(APValue &Result, ASTContext &C, MetaActions &Meta,
                   const_cast<ValueDecl *>(LVBase.get<const ValueDecl *>())));
 
   return SetAndSucceed(Result, EvalResult.Val.Lift(CallExpr->getType()));
+}
+
+bool is_string_literal(APValue &Result, ASTContext &C, MetaActions &Meta,
+                       EvalFn Evaluator, DiagFn Diagnoser,
+                       bool AllowInjection, QualType ResultTy,
+                       SourceRange Range, ArrayRef<Expr *> Args,
+                       Decl *ContainingDecl)
+{
+    assert(Args[0]->getType()->isPointerType());
+    assert(ResultTy == C.BoolTy);
+
+    APValue RV;
+    if (!Evaluator(RV, Args[0], true))
+      return true;
+
+    APValue::LValueBase Base = RV.getLValueBase();
+    const Expr *BaseE = Base.dyn_cast<const Expr*>();
+    return SetAndSucceed(Result, makeBool(C, llvm::isa_and_nonnull<StringLiteral>(BaseE)));
+}
+
+bool string_literal_from(APValue &Result, ASTContext &C, MetaActions &Meta,
+                         EvalFn Evaluator, DiagFn Diagnoser,
+                         bool AllowInjection, QualType ResultTy,
+                         SourceRange Range, ArrayRef<Expr *> Args,
+                         Decl *ContainingDecl)
+{
+    assert(Args[0]->getType()->isPointerType());
+    assert(ResultTy->isPointerType());
+
+    APValue RV;
+    if (!Evaluator(RV, Args[0], true))
+      return true;
+
+    APValue::LValueBase Base = RV.getLValueBase();
+    const Expr *BaseE = Base.dyn_cast<const Expr*>();
+
+    if (llvm::isa_and_nonnull<StringLiteral>(BaseE)) {
+      ArrayRef<APValue::LValuePathEntry> EmptyPath{};
+      return SetAndSucceed(Result, APValue(Base, CharUnits::Zero(), EmptyPath, false, false));
+    }
+    return SetAndSucceed(Result, APValue((const ValueDecl*)nullptr, CharUnits::Zero(), APValue::NoLValuePath(), true));
 }
 
 }  // end namespace clang

--- a/clang/lib/Sema/SemaReflect.cpp
+++ b/clang/lib/Sema/SemaReflect.cpp
@@ -1355,6 +1355,9 @@ ExprResult Sema::BuildCXXMetafunctionExpr(
     case Metafunction::MFRK_sizeT:
       Result = Context.getSizeType();
       return false;
+    case Metafunction::MFRK_charPtr:
+      Result = Context.getPointerType(Context.CharTy.withConst());
+      return false;
     case Metafunction::MFRK_sourceLoc: {
       RecordDecl *SourceLocDecl = lookupStdSourceLocationImpl(KwLoc);
       if (SourceLocDecl)

--- a/libcxx/include/meta
+++ b/libcxx/include/meta
@@ -2378,7 +2378,9 @@ consteval auto is_string_literal(const char* p) -> bool {
 // If p points into a string literal, a pointer to the first character of it
 // Otherwise, nullptr
 consteval auto string_literal_from(const char* p) -> const char* {
-  return __metafunction(meta::detail::__metafn_string_literal_from, p);
+  // Clearly, I implemented this wrong
+  char const* r = __metafunction(meta::detail::__metafn_string_literal_from, p);
+  return r ? p - (p - r) : nullptr;
 }
 
 // Returns a static string having the provided contents.

--- a/libcxx/include/meta
+++ b/libcxx/include/meta
@@ -549,6 +549,10 @@ enum : unsigned {
   // Other bespoke functions (not proposed at this time)
   __metafn_is_access_specified,
   __metafn_reflect_invoke,
+
+  // P3491 string literal manipulation
+  __metafn_is_string_literal,
+  __metafn_string_literal_from,
 };
 
 consteval auto __workaround_expand_compiler_builtins(info type) -> info;
@@ -2364,6 +2368,17 @@ consteval auto define_static_array(R &&elems)
   using ValTy  = ranges::range_value_t<R>;
   meta::info array = meta::reflect_constant_array(elems);
   return span<const ValTy>(extract<const ValTy*>(array), meta::extent(type_of(array)));
+}
+
+// Returns true if this points to a string literal
+consteval auto is_string_literal(const char* p) -> bool {
+  return __metafunction(meta::detail::__metafn_is_string_literal, p);
+}
+
+// If p points into a string literal, a pointer to the first character of it
+// Otherwise, nullptr
+consteval auto string_literal_from(const char* p) -> const char* {
+  return __metafunction(meta::detail::__metafn_string_literal_from, p);
 }
 
 // Returns a static string having the provided contents.

--- a/libcxx/test/std/experimental/reflection/string-literal.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/string-literal.pass.cpp
@@ -2,6 +2,9 @@
 // ADDITIONAL_COMPILE_FLAGS: -freflection
 
 #include <meta>
+#include <string_view>
+
+using namespace std::literals;
 
 constexpr char msg[] = "hello";
 constexpr char const* p = "hello";
@@ -16,8 +19,10 @@ static_assert(!std::is_string_literal(msg));
 static_assert(!std::is_string_literal(msg + 1));
 
 static_assert(std::string_literal_from(p) == p);
+static_assert(std::string_literal_from(p) == "hello"sv);
 static_assert(std::string_literal_from(p + 1) == p);
 static_assert(std::string_literal_from(q) == p);
+static_assert(std::string_literal_from(q) == "hello"sv);
 static_assert(std::string_literal_from(q + 1) == p);
 static_assert(std::string_literal_from(msg) == nullptr);
 

--- a/libcxx/test/std/experimental/reflection/string-literal.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/string-literal.pass.cpp
@@ -1,0 +1,24 @@
+// UNSUPPORTED: c++03 || c++11 || c++14 || c++17 || c++20
+// ADDITIONAL_COMPILE_FLAGS: -freflection
+
+#include <meta>
+
+constexpr char msg[] = "hello";
+constexpr char const* p = "hello";
+constexpr char const* q = p + 1;
+
+static_assert(std::is_string_literal("hello"));
+static_assert(std::is_string_literal(p));
+static_assert(std::is_string_literal(p + 1));
+static_assert(std::is_string_literal(q));
+static_assert(std::is_string_literal(q + 1));
+static_assert(!std::is_string_literal(msg));
+static_assert(!std::is_string_literal(msg + 1));
+
+static_assert(std::string_literal_from(p) == p);
+static_assert(std::string_literal_from(p + 1) == p);
+static_assert(std::string_literal_from(q) == p);
+static_assert(std::string_literal_from(q + 1) == p);
+static_assert(std::string_literal_from(msg) == nullptr);
+
+int main() { }


### PR DESCRIPTION
Adding `std::is_string_literal(p)` (which is in the standard now) and `std::string_literal_from(p)` (which isn't but maybe should be)