### PR TITLE
[P3816] Implement `std::consteval_hash<std::meta::info>` (semi-stable implementation 1)

### DIFF
--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -1842,6 +1842,13 @@ public:
   };
 
 private:
+    static int s_idCounter;
+    int d_id;
+
+public:
+    auto getTypeUniqueId() const -> int { return d_id; }
+
+private:
   /// Bitfields required by the Type class.
   class TypeBitfields {
     friend class Type;
@@ -2320,6 +2327,7 @@ protected:
        bool ConstevalOnly)
       : ExtQualsTypeCommonBase(this,
                                canon.isNull() ? QualType(this_(), 0) : canon) {
+    d_id = ++s_idCounter;
     static_assert(sizeof(*this) <=
                       alignof(decltype(*this)) + sizeof(ExtQualsTypeCommonBase),
                   "changing bitfields changed sizeof(Type)!");

--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -1843,10 +1843,10 @@ public:
 
 private:
     static int s_idCounter;
-    int d_id;
+    int TypeUniqueId = ++s_idCounter;
 
 public:
-    auto getTypeUniqueId() const -> int { return d_id; }
+    auto getTypeUniqueId() const -> int { return TypeUniqueId; }
 
 private:
   /// Bitfields required by the Type class.
@@ -2327,7 +2327,6 @@ protected:
        bool ConstevalOnly)
       : ExtQualsTypeCommonBase(this,
                                canon.isNull() ? QualType(this_(), 0) : canon) {
-    d_id = ++s_idCounter;
     static_assert(sizeof(*this) <=
                       alignof(decltype(*this)) + sizeof(ExtQualsTypeCommonBase),
                   "changing bitfields changed sizeof(Type)!");

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -6423,6 +6423,17 @@ static void appendQualType(llvm::FoldingSetNodeID &ID, const QualType &Ty)
     ID.AddInteger(Ty.getQualifiers().getAsOpaqueValue());
 }
 
+static void appendSourceLocation(llvm::FoldingSetNodeID &ID, const SourceLocation& Loc)
+{
+    ID.AddInteger(Loc.getHashValue());
+}
+
+static void appendSourceRange(llvm::FoldingSetNodeID &ID, const SourceRange& Range)
+{
+    appendSourceLocation(ID, Range.getBegin());
+    appendSourceLocation(ID, Range.getEnd());
+}
+
 bool reflection_hash(APValue &Result, ASTContext &C, MetaActions &Meta,
                     EvalFn Evaluator, DiagFn Diagnoser, bool AllowInjection,
                     QualType ResultTy, SourceRange Range, ArrayRef<Expr *> Args,
@@ -6435,81 +6446,35 @@ bool reflection_hash(APValue &Result, ASTContext &C, MetaActions &Meta,
     return true;
   }
 
-  // TODO(Matt): find difference between isReflectionType() and C.MetaInfoTy
-  //assert(ResultTy == C.MetaInfoTy);
-
   llvm::FoldingSetNodeID ID;
+  ID.AddInteger(static_cast<std::size_t>(R.getReflectionKind()));
 
-  std::size_t seed = 0; // to distinguish hashes of different kinds
   switch (R.getReflectionKind()) {
   case ReflectionKind::Null: {                                      // DONE
-    seed = 0;
+    ID.AddInteger(0);
   } break;
   case ReflectionKind::Type: {                                      // DONE 
-      appendQualType(ID, R.getReflectedType());
-      seed = 1;
+    appendQualType(ID, R.getReflectedType());
   } break;
-  case ReflectionKind::Declaration: {                               // TODO
-    seed = 2; 
-    ValueDecl *D = RV.getReflectedDecl();
-
-    switch (D->getDeclName().getNameKind()) {
-    case DeclarationName::CXXConstructorName: {} break;
-    case DeclarationName::CXXDestructorName: {} break;
-    case DeclarationName::CXXConversionFunctionName: {} break;
-    case DeclarationName::CXXOperatorName: {} break;
-    case DeclarationName::CXXLiteralOperatorName: {} break;
-    default:
-        if (auto *FD = dyn_cast<FieldDecl>(D)) {
-          if (FD->isUnnamedBitField()) {} 
-          else if (FD->isBitField()) {}
-          else { // non-static data member
-          }
-        }
-        else if (isa<ParmVarDecl>(D)) {} 
-        else if (isa<VarDecl>(D)) {} 
-        else if (isa<BindingDecl>(D)) {} 
-        else if (isa<FunctionDecl>(D)) {}
-        else if (isa<EnumConstantDecl>(D)) {} 
-    }
-    llvm_unreachable("unhandled declaration kind");
+  case ReflectionKind::Declaration: {                               // DONE 
+    appendSourceRange(ID, R.getReflectedDecl()->getSourceRange());
   } break;
   case ReflectionKind::Object: {                                    // TODO
-    seed = 3;
+    llvm_unreachable("TODO - Object not yet hashable");
   } break;
-  case ReflectionKind::Value: {                                     // TODO
-    seed = 4;
-    APValue val = R.getReflectedValue();
-    val.Profile(ID);
+  case ReflectionKind::Value: {                                     // DONE
+    R.getReflectedValue().Profile(ID);
   break; }
-  case ReflectionKind::Template: {                                  // TODO
-    seed = 5;
+  case ReflectionKind::Template: {                                  // DONE
+    appendSourceRange(ID, R.getReflectedTemplate().getAsTemplateDecl()->getSourceRange());
   } break;
   case ReflectionKind::Namespace: {                                 // DONE
-    seed = 6;
-    Decl* D = R.getReflectedNamespace();
-    if (isa<TranslationUnitDecl>(D)) { // global namespace
-        ID.AddInteger(0); // nothing else to do
-    }
-    else if (isa<NamespaceDecl>(D)) {
-        NamespaceDecl* ND = dyn_cast<NamespaceDecl>(D);
-        SourceLocation loc = ND->getBeginLoc();
-        ID.AddInteger(loc.getHashValue());
-    }
-    else if (isa<NamespaceAliasDecl>(D)) {
-        NamespaceAliasDecl* ND = dyn_cast<NamespaceAliasDecl>(D);
-        SourceLocation loc = ND->getAliasLoc();
-        ID.AddInteger(loc.getHashValue());
-    }
-    else {
-        llvm_unreachable("unhandled namespace kind");
-    }
+    appendSourceRange(ID, R.getReflectedNamespace()->getSourceRange());
   } break;
-  case ReflectionKind::BaseSpecifier: {                             // TODO
-    seed = 7; 
+  case ReflectionKind::BaseSpecifier: {                             // DONE 
+    appendSourceRange(ID, R.getReflectedBaseSpecifier()->getSourceRange());
   } break;
   case ReflectionKind::DataMemberSpec: {                            // DONE
-    seed = 8;
     TagDataMemberSpec *TDMS = R.getReflectedDataMemberSpec();
     appendQualType(ID, TDMS->Ty);
     if (TDMS->Name) {
@@ -6523,13 +6488,13 @@ bool reflection_hash(APValue &Result, ASTContext &C, MetaActions &Meta,
     }
     ID.AddInteger(TDMS->NoUniqueAddress);
   } break;
-  case ReflectionKind::Annotation: {                                // TODO
-    seed = 9; 
+  case ReflectionKind::Annotation: {                                // DONE 
+    appendSourceLocation(ID, R.getReflectedAnnotation()->getEqLoc());
   } break;
   default:
     llvm_unreachable("unknown reflection kind");
   }
-  ID.AddInteger(seed);
+
   return SetAndSucceed(
     Result,
     APValue(C.MakeIntValue(ID.computeStableHash(), C.getSizeType())));

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -6445,8 +6445,11 @@ bool reflection_hash(APValue &Result, ASTContext &C, MetaActions &Meta,
   case ReflectionKind::Null: {                                      // DONE
     seed = 0;
   } break;
-  case ReflectionKind::Type: {                                      // TODO
-    seed = 1;
+  case ReflectionKind::Type: {                                      // DONE 
+      QualType QT = R.getReflectedType();
+      ID.AddInteger(QT->getTypeUniqueId());
+      ID.AddInteger(QT.getQualifiers().getAsOpaqueValue());
+      seed = 1;
   } break;
   case ReflectionKind::Declaration: {                               // TODO
     seed = 2; 
@@ -6485,6 +6488,19 @@ bool reflection_hash(APValue &Result, ASTContext &C, MetaActions &Meta,
   } break;
   case ReflectionKind::DataMemberSpec: {                            // TODO
     seed = 8;
+    //TagDataMemberSpec *TDMS = RV.getReflectedDataMemberSpec();
+    // TODO: Add the QualType to the hash
+    // TDMS->Ty
+    //if (TDMS->Name) {
+    //    ID.AddString(TDMS->Name.value());
+    //}
+    //if (TDMS->Alignment) {
+    //    ID.AddInteger(TDMS->Alignment.value());
+    //}
+    //if (TDMS->BitWidth) {
+    //    ID.AddInteger(TDMS->BitWidth.value());
+    //}
+    //ID.AddInteger(TDMS->NoUniqueAddress);
   } break;
   case ReflectionKind::Annotation: {                                // TODO
     seed = 9; 

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -711,9 +711,9 @@ static bool reflect_invoke(APValue &Result, ASTContext &C, MetaActions &Meta,
                            SourceRange Range, ArrayRef<Expr *> Args,
                            Decl *ContainingDecl);
 
-               // ================================================
-               // std::hash<std::meta::info> specialization helper
-               // ================================================
+          // ==========================================================
+          // std::consteval_hash<std::meta::info> specialization helper
+          // ==========================================================
 
 static bool reflection_hash(APValue &Result, ASTContext &C, MetaActions &Meta,
                             EvalFn Evaluator, DiagFn Diagnoser, bool AllowInjection,
@@ -854,7 +854,7 @@ static constexpr Metafunction Metafunctions[] = {
   { Metafunction::MFRK_bool, 1, 1, is_access_specified },
   { Metafunction::MFRK_metaInfo, 5, 5, reflect_invoke },
 
-  // std::hash<std::meta::info> specialization helper
+  // std::consteval_hash<std::meta::info> specialization helper
   { Metafunction::MFRK_sizeT, 1, 1, reflection_hash },
 };
 constexpr const unsigned NumMetafunctions = sizeof(Metafunctions) /
@@ -6451,12 +6451,36 @@ bool reflection_hash(APValue &Result, ASTContext &C, MetaActions &Meta,
   } break;
   case ReflectionKind::Declaration: {                               // TODO
     seed = 2; 
+    ValueDecl *D = RV.getReflectedDecl();
+
+    switch (D->getDeclName().getNameKind()) {
+    case DeclarationName::CXXConstructorName: {} break;
+    case DeclarationName::CXXDestructorName: {} break;
+    case DeclarationName::CXXConversionFunctionName: {} break;
+    case DeclarationName::CXXOperatorName: {} break;
+    case DeclarationName::CXXLiteralOperatorName: {} break;
+    default:
+        if (auto *FD = dyn_cast<FieldDecl>(D)) {
+          if (FD->isUnnamedBitField()) {} 
+          else if (FD->isBitField()) {}
+          else { // non-static data member
+          }
+        }
+        else if (isa<ParmVarDecl>(D)) {} 
+        else if (isa<VarDecl>(D)) {} 
+        else if (isa<BindingDecl>(D)) {} 
+        else if (isa<FunctionDecl>(D)) {}
+        else if (isa<EnumConstantDecl>(D)) {} 
+    }
+    llvm_unreachable("unhandled declaration kind");
   } break;
   case ReflectionKind::Object: {                                    // TODO
     seed = 3;
   } break;
   case ReflectionKind::Value: {                                     // TODO
     seed = 4;
+    APValue val = R.getReflectedValue();
+    val.Profile(ID);
   break; }
   case ReflectionKind::Template: {                                  // TODO
     seed = 5;

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -6435,32 +6435,30 @@ static void appendSourceRange(llvm::FoldingSetNodeID &ID, const SourceRange& Ran
     appendSourceLocation(ID, Range.getEnd());
 }
 
-static void appendReflection(ASTContext &C, llvm::FoldingSetNodeID &ID, const APValue& APV);
-static void appendAPValue(ASTContext &C, llvm::FoldingSetNodeID &ID, const APValue& APV);
-
 static void appendLValue(ASTContext &C, llvm::FoldingSetNodeID &ID, const APValue &APV) {
-    const auto &Base = APV.getLValueBase();
-
-    if (!Base.is<const ValueDecl *>()) {
-      llvm_unreachable("can only reflect value decls");
-    }
-    
-    const ValueDecl *VD = Base.get<const ValueDecl *>();
-    if (!VD) {
-      ID.AddInteger(0); // nullptr;
-      return;
-    }
-
-    ID.AddString(VD->getQualifiedNameAsString());
-    appendQualType(ID, VD->getType());
-    ID.AddInteger(VD->getKind());
-
-    // Are these needed?
-    ID.AddInteger(APV.getLValueOffset().getQuantity());
-    ID.AddBoolean(APV.getLValueBase().isNull());
-    ID.AddBoolean(APV.isLValueOnePastTheEnd());
+  const auto &Base = APV.getLValueBase();
+  
+  if (!Base.is<const ValueDecl *>()) {
+    llvm_unreachable("can only reflect value decls");
+  }
+  
+  const ValueDecl *VD = Base.get<const ValueDecl *>();
+  if (!VD) {
+    ID.AddInteger(0); // nullptr;
+    return;
+  }
+  
+  ID.AddString(VD->getQualifiedNameAsString());
+  appendQualType(ID, VD->getType());
+  ID.AddInteger(VD->getKind());
+  
+  // Are these needed?
+  ID.AddInteger(APV.getLValueOffset().getQuantity());
+  ID.AddBoolean(APV.getLValueBase().isNull());
+  ID.AddBoolean(APV.isLValueOnePastTheEnd());
 }
 
+static void appendReflection(ASTContext &C, llvm::FoldingSetNodeID &ID, const APValue& APV);
 static void appendAPValue(ASTContext &C, llvm::FoldingSetNodeID &ID, const APValue& APV)
 {
     ID.AddInteger(APV.getKind());

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -6485,9 +6485,6 @@ bool reflection_hash(APValue &Result, ASTContext &C, MetaActions &Meta,
     seed = 7; 
   } break;
   case ReflectionKind::DataMemberSpec: {                            // DONE
-  return SetAndSucceed(
-    Result,
-    APValue(C.MakeIntValue(1337, C.getSizeType())));
     seed = 8;
     TagDataMemberSpec *TDMS = R.getReflectedDataMemberSpec();
     appendQualType(ID, TDMS->Ty);

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -6436,6 +6436,31 @@ static void appendSourceRange(llvm::FoldingSetNodeID &ID, const SourceRange& Ran
 }
 
 static void appendReflection(ASTContext &C, llvm::FoldingSetNodeID &ID, const APValue& APV);
+static void appendAPValue(ASTContext &C, llvm::FoldingSetNodeID &ID, const APValue& APV);
+
+static void appendLValue(ASTContext &C, llvm::FoldingSetNodeID &ID, const APValue &APV) {
+    const auto &Base = APV.getLValueBase();
+
+    if (!Base.is<const ValueDecl *>()) {
+      llvm_unreachable("can only reflect value decls");
+    }
+    
+    const ValueDecl *VD = Base.get<const ValueDecl *>();
+    if (!VD) {
+      ID.AddInteger(0); // nullptr;
+      return;
+    }
+
+    ID.AddString(VD->getQualifiedNameAsString());
+    appendQualType(ID, VD->getType());
+    ID.AddInteger(VD->getKind());
+
+    ID.AddInteger(APV.getLValueOffset().getQuantity());
+
+    ID.AddBoolean(APV.getLValueBase().isNull());
+    ID.AddBoolean(APV.isLValueOnePastTheEnd());
+}
+
 static void appendAPValue(ASTContext &C, llvm::FoldingSetNodeID &ID, const APValue& APV)
 {
     ID.AddInteger(APV.getKind());
@@ -6462,7 +6487,7 @@ static void appendAPValue(ASTContext &C, llvm::FoldingSetNodeID &ID, const APVal
           APV.getComplexFloatReal().Profile(ID);
         } break;
         case APValue::LValue: { // TODO: Fill this in
-          llvm_unreachable("TODO: Hashing APValue::LValue not implemented");
+          appendLValue(C, ID, APV);
         } break;
         case APValue::Vector: {
           for (std::size_t i = 0; i != APV.getVectorLength(); ++i) {

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -6435,7 +6435,7 @@ static void appendSourceRange(llvm::FoldingSetNodeID &ID, const SourceRange& Ran
     appendSourceLocation(ID, Range.getEnd());
 }
 
-static void appendAPValue(llvm::FoldingSetNodeID &ID, const APValue& APV)
+static void appendAPValue(ASTContext &C, llvm::FoldingSetNodeID &ID, const APValue& APV)
 {
     ID.AddInteger(APV.getKind());
     switch (APV.getKind()) {
@@ -6465,15 +6465,15 @@ static void appendAPValue(llvm::FoldingSetNodeID &ID, const APValue& APV)
         } break;
         case APValue::Vector: {
           for (std::size_t i = 0; i != APV.getVectorLength(); ++i) {
-            appendAPValue(ID, APV.getVectorElt(i));
+            appendAPValue(C, ID, APV.getVectorElt(i));
           }
         } break;
         case APValue::Array: {
           for (std::size_t i = 0; i != APV.getArraySize(); ++i) {
             if (i < APV.getArrayInitializedElts()) {
-              appendAPValue(ID, APV.getArrayInitializedElt(i));
+              appendAPValue(C, ID, APV.getArrayInitializedElt(i));
             } else {
-              appendAPValue(ID, APV.getArrayFiller());
+              appendAPValue(C, ID, APV.getArrayFiller());
             }
           }
         } break;
@@ -6482,18 +6482,23 @@ static void appendAPValue(llvm::FoldingSetNodeID &ID, const APValue& APV)
         // objects of these types with the same values for x and y hash to the same.
         case APValue::Struct: {
           for (std::size_t i = 0; i != APV.getStructNumFields(); ++i) {
-            appendAPValue(ID, APV.getStructField(i));
+            appendAPValue(C, ID, APV.getStructField(i));
           }
           for (std::size_t i = 0; i != APV.getStructNumBases(); ++i) {
-            appendAPValue(ID, APV.getStructBase(i));
+            appendAPValue(C, ID, APV.getStructBase(i));
           }
         } break;
         case APValue::Union: {
           llvm_unreachable("TODO: Hashing APValue::Union not implemented");
         } break;
+
+        // Hash is based on the QualType of the struct that the pointer is a member of,
+        // and the name of the field.
         case APValue::MemberPointer: {
-          auto* MPD = APV.getMemberPointerDecl();
-          llvm_unreachable("TODO: Hashing APValue::MemberPointer not implemented");
+          auto* VD = APV.getMemberPointerDecl();
+          ID.AddString(VD->getNameAsString());
+          const auto *RD = dyn_cast<CXXRecordDecl>(VD->getDeclContext());
+          appendQualType(ID, C.getRecordType(RD));
         } break;
         case APValue::AddrLabelDiff: {
           llvm_unreachable("TODO: Hashing APValue::AddrLabelDiff not implemented");
@@ -6530,10 +6535,10 @@ bool reflection_hash(APValue &Result, ASTContext &C, MetaActions &Meta,
     appendQualType(ID, R.getReflectedType());
   } break;
   case ReflectionKind::Object: {
-    appendAPValue(ID, R.getReflectedObject());
+    appendAPValue(C, ID, R.getReflectedObject());
   } break;
   case ReflectionKind::Value: {
-    appendAPValue(ID, R.getReflectedValue());
+    appendAPValue(C, ID, R.getReflectedValue());
   } break;
   case ReflectionKind::Declaration: {
     appendSourceRange(ID, R.getReflectedDecl()->getSourceRange());

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -6511,9 +6511,12 @@ static void appendAPValue(ASTContext &C, llvm::FoldingSetNodeID &ID, const APVal
           appendQualType(ID, C.getRecordType(RD));
         } break;
 
+        // I believe this is only usable in C, so we cannot hope to get a
+        // reflection of it.
         case APValue::AddrLabelDiff: {
-          llvm_unreachable("TODO: Hashing APValue::AddrLabelDiff not implemented");
+          llvm_unreachable("Non-standard extension not supported in C++");
         } break;
+
         case APValue::Reflection: {
           auto V = APV;
           while (V.getReflectionDepth() > 0) {

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -6442,19 +6442,25 @@ bool reflection_hash(APValue &Result, ASTContext &C, MetaActions &Meta,
 
   std::size_t seed = 0; // to distinguish hashes of different kinds
   switch (R.getReflectionKind()) {
-  case ReflectionKind::Null:
-    seed = 0; break;
-  case ReflectionKind::Type:
-    seed = 1; break;
-  case ReflectionKind::Declaration:
-    seed = 2; break;
-  case ReflectionKind::Object:
-    seed = 3; break;
-  case ReflectionKind::Value:
-    seed = 4; break;
-  case ReflectionKind::Template:
-    seed = 5; break;
-  case ReflectionKind::Namespace: {
+  case ReflectionKind::Null: {                                      // DONE
+    seed = 0;
+  } break;
+  case ReflectionKind::Type: {                                      // TODO
+    seed = 1;
+  } break;
+  case ReflectionKind::Declaration: {                               // TODO
+    seed = 2; 
+  } break;
+  case ReflectionKind::Object: {                                    // TODO
+    seed = 3;
+  } break;
+  case ReflectionKind::Value: {                                     // TODO
+    seed = 4;
+  break; }
+  case ReflectionKind::Template: {                                  // TODO
+    seed = 5;
+  } break;
+  case ReflectionKind::Namespace: {                                 // DONE
     seed = 6;
     Decl* D = R.getReflectedNamespace();
     if (isa<TranslationUnitDecl>(D)) { // global namespace
@@ -6474,12 +6480,15 @@ bool reflection_hash(APValue &Result, ASTContext &C, MetaActions &Meta,
         llvm_unreachable("unhandled namespace kind");
     }
   } break;
-  case ReflectionKind::BaseSpecifier:
-    seed = 7; break;
-  case ReflectionKind::DataMemberSpec:
-    seed = 8; break;
-  case ReflectionKind::Annotation:
-    seed = 9; break;
+  case ReflectionKind::BaseSpecifier: {                             // TODO
+    seed = 7; 
+  } break;
+  case ReflectionKind::DataMemberSpec: {                            // TODO
+    seed = 8;
+  } break;
+  case ReflectionKind::Annotation: {                                // TODO
+    seed = 9; 
+  } break;
   default:
     llvm_unreachable("unknown reflection kind");
   }

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -6455,8 +6455,8 @@ static void appendLValue(ASTContext &C, llvm::FoldingSetNodeID &ID, const APValu
     appendQualType(ID, VD->getType());
     ID.AddInteger(VD->getKind());
 
+    // Are these needed?
     ID.AddInteger(APV.getLValueOffset().getQuantity());
-
     ID.AddBoolean(APV.getLValueBase().isNull());
     ID.AddBoolean(APV.isLValueOnePastTheEnd());
 }

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -6473,11 +6473,10 @@ bool reflection_hash(APValue &Result, ASTContext &C, MetaActions &Meta,
     appendSourceRange(ID, R.getReflectedNamespace()->getSourceRange());
   } break;
   case ReflectionKind::EntityProxy: {
-    llvm_unreachable("TODO - EntityProxy not yet hashable");
     appendSourceLocation(ID, R.getReflectedEntityProxy()->getLocation());
   } break;
   case ReflectionKind::Parameter: {
-    llvm_unreachable("TODO - Parameter not yet hashable");
+    appendSourceLocation(ID, R.getReflectedParameter()->getLocation());
   } break;
   case ReflectionKind::BaseSpecifier: {
     appendSourceRange(ID, R.getReflectedBaseSpecifier()->getSourceRange());

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -6417,6 +6417,12 @@ bool reflect_invoke(APValue &Result, ASTContext &C, MetaActions &Meta,
   return SetAndSucceed(Result, EvalResult.Val.Lift(CallExpr->getType()));
 }
 
+static void appendQualType(llvm::FoldingSetNodeID &ID, const QualType &Ty)
+{
+    ID.AddInteger(Ty->getTypeUniqueId());
+    ID.AddInteger(Ty.getQualifiers().getAsOpaqueValue());
+}
+
 bool reflection_hash(APValue &Result, ASTContext &C, MetaActions &Meta,
                     EvalFn Evaluator, DiagFn Diagnoser, bool AllowInjection,
                     QualType ResultTy, SourceRange Range, ArrayRef<Expr *> Args,
@@ -6446,9 +6452,7 @@ bool reflection_hash(APValue &Result, ASTContext &C, MetaActions &Meta,
     seed = 0;
   } break;
   case ReflectionKind::Type: {                                      // DONE 
-      QualType QT = R.getReflectedType();
-      ID.AddInteger(QT->getTypeUniqueId());
-      ID.AddInteger(QT.getQualifiers().getAsOpaqueValue());
+      appendQualType(ID, R.getReflectedType());
       seed = 1;
   } break;
   case ReflectionKind::Declaration: {                               // TODO

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -6460,8 +6460,7 @@ static void appendAPValue(llvm::FoldingSetNodeID &ID, const APValue& APV)
           APV.getComplexFloatImag().Profile(ID);
           APV.getComplexFloatReal().Profile(ID);
         } break;
-        case APValue::LValue: {
-          appendQualType(ID, APV.getLValueBase().getType());
+        case APValue::LValue: { // TODO: Fill this in
           llvm_unreachable("TODO: Hashing APValue::LValue not implemented");
         } break;
         case APValue::Vector: {
@@ -6478,13 +6477,22 @@ static void appendAPValue(llvm::FoldingSetNodeID &ID, const APValue& APV)
             }
           }
         } break;
+        // Should this be unique per type?
+        // Currently, given struct F { int x, y; }; and struct G { int x, y; };
+        // objects of these types with the same values for x and y hash to the same.
         case APValue::Struct: {
-          llvm_unreachable("TODO: Hashing APValue::Struct not implemented");
+          for (std::size_t i = 0; i != APV.getStructNumFields(); ++i) {
+            appendAPValue(ID, APV.getStructField(i));
+          }
+          for (std::size_t i = 0; i != APV.getStructNumBases(); ++i) {
+            appendAPValue(ID, APV.getStructBase(i));
+          }
         } break;
         case APValue::Union: {
           llvm_unreachable("TODO: Hashing APValue::Union not implemented");
         } break;
         case APValue::MemberPointer: {
+          auto* MPD = APV.getMemberPointerDecl();
           llvm_unreachable("TODO: Hashing APValue::MemberPointer not implemented");
         } break;
         case APValue::AddrLabelDiff: {

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -6461,6 +6461,7 @@ static void appendAPValue(llvm::FoldingSetNodeID &ID, const APValue& APV)
           APV.getComplexFloatReal().Profile(ID);
         } break;
         case APValue::LValue: {
+          appendQualType(ID, APV.getLValueBase().getType());
           llvm_unreachable("TODO: Hashing APValue::LValue not implemented");
         } break;
         case APValue::Vector: {
@@ -6469,7 +6470,6 @@ static void appendAPValue(llvm::FoldingSetNodeID &ID, const APValue& APV)
           }
         } break;
         case APValue::Array: {
-          llvm_unreachable("TODO: Hashing APValue::Array not implemented");
           for (std::size_t i = 0; i != APV.getArraySize(); ++i) {
             if (i < APV.getArrayInitializedElts()) {
               appendAPValue(ID, APV.getArrayInitializedElt(i));
@@ -6491,7 +6491,6 @@ static void appendAPValue(llvm::FoldingSetNodeID &ID, const APValue& APV)
           llvm_unreachable("TODO: Hashing APValue::AddrLabelDiff not implemented");
         } break;
         case APValue::Reflection: {
-          ID.AddInteger(1);
           llvm_unreachable("TODO: Hashing APValue::Reflection not implemented");
         } break;
         default: {

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -711,6 +711,15 @@ static bool reflect_invoke(APValue &Result, ASTContext &C, MetaActions &Meta,
                            SourceRange Range, ArrayRef<Expr *> Args,
                            Decl *ContainingDecl);
 
+               // ================================================
+               // std::hash<std::meta::info> specialization helper
+               // ================================================
+
+static bool reflection_hash(APValue &Result, ASTContext &C, MetaActions &Meta,
+                            EvalFn Evaluator, DiagFn Diagnoser, bool AllowInjection,
+                            QualType ResultTy, SourceRange Range,
+                            ArrayRef<Expr *> Args, Decl *ContainingDecl);
+
 // -----------------------------------------------------------------------------
 // Metafunction table
 //
@@ -844,6 +853,9 @@ static constexpr Metafunction Metafunctions[] = {
   // Other bespoke functions (not proposed at this time)
   { Metafunction::MFRK_bool, 1, 1, is_access_specified },
   { Metafunction::MFRK_metaInfo, 5, 5, reflect_invoke },
+
+  // std::hash<std::meta::info> specialization helper
+  { Metafunction::MFRK_sizeT, 1, 1, reflection_hash },
 };
 constexpr const unsigned NumMetafunctions = sizeof(Metafunctions) /
                                             sizeof(Metafunction);
@@ -6403,6 +6415,25 @@ bool reflect_invoke(APValue &Result, ASTContext &C, MetaActions &Meta,
                   const_cast<ValueDecl *>(LVBase.get<const ValueDecl *>())));
 
   return SetAndSucceed(Result, EvalResult.Val.Lift(CallExpr->getType()));
+}
+
+bool reflection_hash(APValue &Result, ASTContext &C, MetaActions &Meta,
+                    EvalFn Evaluator, DiagFn Diagnoser, bool AllowInjection,
+                    QualType ResultTy, SourceRange Range, ArrayRef<Expr *> Args,
+                    Decl *ContainingDecl) {
+  assert(Args[0]->getType()->isReflectionType());
+  assert(ResultTy == C.getSizeType());
+
+  APValue R;
+  if (!Evaluator(R, Args[0], true)) {
+    return true;
+  }
+
+  llvm::FoldingSetNodeID ID;
+  R.getReflectedType().Profile(ID);
+  return SetAndSucceed(
+    Result,
+    APValue(C.MakeIntValue(ID.ComputeHash(), C.getSizeType())));
 }
 
 }  // end namespace clang

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -6418,24 +6418,24 @@ bool reflect_invoke(APValue &Result, ASTContext &C, MetaActions &Meta,
   return SetAndSucceed(Result, EvalResult.Val.Lift(CallExpr->getType()));
 }
 
-static void appendQualType(llvm::FoldingSetNodeID &ID, const QualType &Ty)
+static void AppendQualType(llvm::FoldingSetNodeID &ID, const QualType &Ty)
 {
     ID.AddInteger(Ty->getTypeUniqueId());
     ID.AddInteger(Ty.getQualifiers().getAsOpaqueValue());
 }
 
-static void appendSourceLocation(llvm::FoldingSetNodeID &ID, const SourceLocation& Loc)
+static void AppendSourceLocation(llvm::FoldingSetNodeID &ID, const SourceLocation& Loc)
 {
     ID.AddInteger(Loc.getHashValue());
 }
 
-static void appendSourceRange(llvm::FoldingSetNodeID &ID, const SourceRange& Range)
+static void AppendSourceRange(llvm::FoldingSetNodeID &ID, const SourceRange& Range)
 {
-    appendSourceLocation(ID, Range.getBegin());
-    appendSourceLocation(ID, Range.getEnd());
+    AppendSourceLocation(ID, Range.getBegin());
+    AppendSourceLocation(ID, Range.getEnd());
 }
 
-static void appendLValue(ASTContext &C, llvm::FoldingSetNodeID &ID, const APValue &APV) {
+static void AppendLValue(ASTContext &C, llvm::FoldingSetNodeID &ID, const APValue &APV) {
   const auto &Base = APV.getLValueBase();
   
   if (!Base.is<const ValueDecl *>()) {
@@ -6449,7 +6449,7 @@ static void appendLValue(ASTContext &C, llvm::FoldingSetNodeID &ID, const APValu
   }
   
   ID.AddString(VD->getQualifiedNameAsString());
-  appendQualType(ID, VD->getType());
+  AppendQualType(ID, VD->getType());
   ID.AddInteger(VD->getKind());
   
   // Are these needed?
@@ -6458,8 +6458,8 @@ static void appendLValue(ASTContext &C, llvm::FoldingSetNodeID &ID, const APValu
   ID.AddBoolean(APV.isLValueOnePastTheEnd());
 }
 
-static void appendReflection(ASTContext &C, llvm::FoldingSetNodeID &ID, const APValue& APV);
-static void appendAPValue(ASTContext &C, llvm::FoldingSetNodeID &ID, const APValue& APV)
+static void AppendReflection(ASTContext &C, llvm::FoldingSetNodeID &ID, const APValue& APV);
+static void AppendAPValue(ASTContext &C, llvm::FoldingSetNodeID &ID, const APValue& APV)
 {
     ID.AddInteger(APV.getKind());
     switch (APV.getKind()) {
@@ -6485,11 +6485,11 @@ static void appendAPValue(ASTContext &C, llvm::FoldingSetNodeID &ID, const APVal
           APV.getComplexFloatReal().Profile(ID);
         } break;
         case APValue::LValue: {
-          appendLValue(C, ID, APV);
+          AppendLValue(C, ID, APV);
         } break;
         case APValue::Vector: {
           for (std::size_t i = 0; i != APV.getVectorLength(); ++i) {
-            appendAPValue(C, ID, APV.getVectorElt(i));
+            AppendAPValue(C, ID, APV.getVectorElt(i));
           }
         } break;
 
@@ -6497,9 +6497,9 @@ static void appendAPValue(ASTContext &C, llvm::FoldingSetNodeID &ID, const APVal
         case APValue::Array: {
           for (std::size_t i = 0; i != APV.getArraySize(); ++i) {
             if (i < APV.getArrayInitializedElts()) {
-              appendAPValue(C, ID, APV.getArrayInitializedElt(i));
+              AppendAPValue(C, ID, APV.getArrayInitializedElt(i));
             } else {
-              appendAPValue(C, ID, APV.getArrayFiller());
+              AppendAPValue(C, ID, APV.getArrayFiller());
             }
           }
         } break;
@@ -6509,10 +6509,10 @@ static void appendAPValue(ASTContext &C, llvm::FoldingSetNodeID &ID, const APVal
         // objects of these types with the same values for x and y hash to the same.
         case APValue::Struct: {
           for (std::size_t i = 0; i != APV.getStructNumFields(); ++i) {
-            appendAPValue(C, ID, APV.getStructField(i));
+            AppendAPValue(C, ID, APV.getStructField(i));
           }
           for (std::size_t i = 0; i != APV.getStructNumBases(); ++i) {
-            appendAPValue(C, ID, APV.getStructBase(i));
+            AppendAPValue(C, ID, APV.getStructBase(i));
           }
         } break;
 
@@ -6520,9 +6520,9 @@ static void appendAPValue(ASTContext &C, llvm::FoldingSetNodeID &ID, const APVal
         case APValue::Union: {
           const auto *ActiveField = APV.getUnionField();
           ID.AddString(ActiveField->getName());
-          appendQualType(ID, ActiveField->getType());
-          appendQualType(ID, C.getRecordType(ActiveField->getParent()));
-          appendAPValue(C, ID, APV.getUnionValue());
+          AppendQualType(ID, ActiveField->getType());
+          AppendQualType(ID, C.getRecordType(ActiveField->getParent()));
+          AppendAPValue(C, ID, APV.getUnionValue());
         } break;
 
         // Hash is based on the QualType of the struct that the pointer is a member of,
@@ -6531,7 +6531,7 @@ static void appendAPValue(ASTContext &C, llvm::FoldingSetNodeID &ID, const APVal
           auto* VD = APV.getMemberPointerDecl();
           ID.AddString(VD->getNameAsString());
           const auto *RD = dyn_cast<CXXRecordDecl>(VD->getDeclContext());
-          appendQualType(ID, C.getRecordType(RD));
+          AppendQualType(ID, C.getRecordType(RD));
         } break;
 
         // I believe this is only usable in C, so we cannot hope to get a
@@ -6546,7 +6546,7 @@ static void appendAPValue(ASTContext &C, llvm::FoldingSetNodeID &ID, const APVal
             ID.AddInteger(V.getReflectionDepth());
             V = V.Lower();
           }
-          appendReflection(C, ID, V);
+          AppendReflection(C, ID, V);
         } break;
         default: {
             llvm_unreachable("unknown ap value");
@@ -6554,7 +6554,7 @@ static void appendAPValue(ASTContext &C, llvm::FoldingSetNodeID &ID, const APVal
     }
 }
 
-void appendReflection(ASTContext &C, llvm::FoldingSetNodeID &ID, const APValue& APV)
+void AppendReflection(ASTContext &C, llvm::FoldingSetNodeID &ID, const APValue& APV)
 {
   ID.AddInteger(static_cast<std::size_t>(APV.getReflectionKind()));
 
@@ -6563,35 +6563,35 @@ void appendReflection(ASTContext &C, llvm::FoldingSetNodeID &ID, const APValue& 
     ID.AddInteger(0);
   } break;
   case ReflectionKind::Type: {
-    appendQualType(ID, APV.getReflectedType());
+    AppendQualType(ID, APV.getReflectedType());
   } break;
   case ReflectionKind::Object: {
-    appendAPValue(C, ID, APV.getReflectedObject());
+    AppendAPValue(C, ID, APV.getReflectedObject());
   } break;
   case ReflectionKind::Value: {
-    appendAPValue(C, ID, APV.getReflectedValue());
+    AppendAPValue(C, ID, APV.getReflectedValue());
   } break;
   case ReflectionKind::Declaration: {
-    appendSourceRange(ID, APV.getReflectedDecl()->getSourceRange());
+    AppendSourceRange(ID, APV.getReflectedDecl()->getSourceRange());
   } break;
   case ReflectionKind::Template: {
-    appendSourceRange(ID, APV.getReflectedTemplate().getAsTemplateDecl()->getSourceRange());
+    AppendSourceRange(ID, APV.getReflectedTemplate().getAsTemplateDecl()->getSourceRange());
   } break;
   case ReflectionKind::Namespace: {
-    appendSourceRange(ID, APV.getReflectedNamespace()->getSourceRange());
+    AppendSourceRange(ID, APV.getReflectedNamespace()->getSourceRange());
   } break;
   case ReflectionKind::EntityProxy: {
-    appendSourceLocation(ID, APV.getReflectedEntityProxy()->getLocation());
+    AppendSourceLocation(ID, APV.getReflectedEntityProxy()->getLocation());
   } break;
   case ReflectionKind::Parameter: {
-    appendSourceLocation(ID, APV.getReflectedParameter()->getLocation());
+    AppendSourceLocation(ID, APV.getReflectedParameter()->getLocation());
   } break;
   case ReflectionKind::BaseSpecifier: {
-    appendSourceRange(ID, APV.getReflectedBaseSpecifier()->getSourceRange());
+    AppendSourceRange(ID, APV.getReflectedBaseSpecifier()->getSourceRange());
   } break;
   case ReflectionKind::DataMemberSpec: {
     TagDataMemberSpec *TDMS = APV.getReflectedDataMemberSpec();
-    appendQualType(ID, TDMS->Ty);
+    AppendQualType(ID, TDMS->Ty);
     if (TDMS->Name) {
         ID.AddString(TDMS->Name.value());
     }
@@ -6604,7 +6604,7 @@ void appendReflection(ASTContext &C, llvm::FoldingSetNodeID &ID, const APValue& 
     ID.AddInteger(TDMS->NoUniqueAddress);
   } break;
   case ReflectionKind::Annotation: {
-    appendSourceLocation(ID, APV.getReflectedAnnotation()->getEqLoc());
+    AppendSourceLocation(ID, APV.getReflectedAnnotation()->getEqLoc());
   } break;
   default:
     llvm_unreachable("unknown reflection kind");
@@ -6624,7 +6624,7 @@ bool reflection_hash(APValue &Result, ASTContext &C, MetaActions &Meta,
   }
 
   llvm::FoldingSetNodeID ID;
-  appendReflection(C, ID, R);
+  AppendReflection(C, ID, R);
   return SetAndSucceed(
     Result,
     APValue(C.MakeIntValue(ID.computeStableHash(), C.getSizeType())));

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -6477,6 +6477,7 @@ static void appendAPValue(ASTContext &C, llvm::FoldingSetNodeID &ID, const APVal
             }
           }
         } break;
+        
         // Should this be unique per type?
         // Currently, given struct F { int x, y; }; and struct G { int x, y; };
         // objects of these types with the same values for x and y hash to the same.
@@ -6488,8 +6489,14 @@ static void appendAPValue(ASTContext &C, llvm::FoldingSetNodeID &ID, const APVal
             appendAPValue(C, ID, APV.getStructBase(i));
           }
         } break;
+
+        // Hash is based on the Union QualType as well as the name and value of the field.
         case APValue::Union: {
-          llvm_unreachable("TODO: Hashing APValue::Union not implemented");
+          const auto *ActiveField = APV.getUnionField();
+          ID.AddString(ActiveField->getName());
+          appendQualType(ID, ActiveField->getType());
+          appendQualType(ID, C.getRecordType(ActiveField->getParent()));
+          appendAPValue(C, ID, APV.getUnionValue());
         } break;
 
         // Hash is based on the QualType of the struct that the pointer is a member of,
@@ -6500,6 +6507,7 @@ static void appendAPValue(ASTContext &C, llvm::FoldingSetNodeID &ID, const APVal
           const auto *RD = dyn_cast<CXXRecordDecl>(VD->getDeclContext());
           appendQualType(ID, C.getRecordType(RD));
         } break;
+
         case APValue::AddrLabelDiff: {
           llvm_unreachable("TODO: Hashing APValue::AddrLabelDiff not implemented");
         } break;

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -6435,6 +6435,7 @@ static void appendSourceRange(llvm::FoldingSetNodeID &ID, const SourceRange& Ran
     appendSourceLocation(ID, Range.getEnd());
 }
 
+static void appendReflection(ASTContext &C, llvm::FoldingSetNodeID &ID, const APValue& APV);
 static void appendAPValue(ASTContext &C, llvm::FoldingSetNodeID &ID, const APValue& APV)
 {
     ID.AddInteger(APV.getKind());
@@ -6468,6 +6469,8 @@ static void appendAPValue(ASTContext &C, llvm::FoldingSetNodeID &ID, const APVal
             appendAPValue(C, ID, APV.getVectorElt(i));
           }
         } break;
+
+        // Value is obtained by recursing and hashing the inner values.
         case APValue::Array: {
           for (std::size_t i = 0; i != APV.getArraySize(); ++i) {
             if (i < APV.getArrayInitializedElts()) {
@@ -6477,7 +6480,7 @@ static void appendAPValue(ASTContext &C, llvm::FoldingSetNodeID &ID, const APVal
             }
           }
         } break;
-        
+
         // Should this be unique per type?
         // Currently, given struct F { int x, y; }; and struct G { int x, y; };
         // objects of these types with the same values for x and y hash to the same.
@@ -6512,12 +6515,74 @@ static void appendAPValue(ASTContext &C, llvm::FoldingSetNodeID &ID, const APVal
           llvm_unreachable("TODO: Hashing APValue::AddrLabelDiff not implemented");
         } break;
         case APValue::Reflection: {
-          llvm_unreachable("TODO: Hashing APValue::Reflection not implemented");
+          auto V = APV;
+          while (V.getReflectionDepth() > 0) {
+            ID.AddInteger(V.getReflectionDepth());
+            V = V.Lower();
+          }
+          appendReflection(C, ID, V);
         } break;
         default: {
             llvm_unreachable("unknown ap value");
         }
     }
+}
+
+void appendReflection(ASTContext &C, llvm::FoldingSetNodeID &ID, const APValue& APV)
+{
+  ID.AddInteger(static_cast<std::size_t>(APV.getReflectionKind()));
+
+  switch (APV.getReflectionKind()) {
+  case ReflectionKind::Null: {
+    ID.AddInteger(0);
+  } break;
+  case ReflectionKind::Type: {
+    appendQualType(ID, APV.getReflectedType());
+  } break;
+  case ReflectionKind::Object: {
+    appendAPValue(C, ID, APV.getReflectedObject());
+  } break;
+  case ReflectionKind::Value: {
+    appendAPValue(C, ID, APV.getReflectedValue());
+  } break;
+  case ReflectionKind::Declaration: {
+    appendSourceRange(ID, APV.getReflectedDecl()->getSourceRange());
+  } break;
+  case ReflectionKind::Template: {
+    appendSourceRange(ID, APV.getReflectedTemplate().getAsTemplateDecl()->getSourceRange());
+  } break;
+  case ReflectionKind::Namespace: {
+    appendSourceRange(ID, APV.getReflectedNamespace()->getSourceRange());
+  } break;
+  case ReflectionKind::EntityProxy: {
+    appendSourceLocation(ID, APV.getReflectedEntityProxy()->getLocation());
+  } break;
+  case ReflectionKind::Parameter: {
+    appendSourceLocation(ID, APV.getReflectedParameter()->getLocation());
+  } break;
+  case ReflectionKind::BaseSpecifier: {
+    appendSourceRange(ID, APV.getReflectedBaseSpecifier()->getSourceRange());
+  } break;
+  case ReflectionKind::DataMemberSpec: {
+    TagDataMemberSpec *TDMS = APV.getReflectedDataMemberSpec();
+    appendQualType(ID, TDMS->Ty);
+    if (TDMS->Name) {
+        ID.AddString(TDMS->Name.value());
+    }
+    if (TDMS->Alignment) {
+        ID.AddInteger(TDMS->Alignment.value());
+    }
+    if (TDMS->BitWidth) {
+        ID.AddInteger(TDMS->BitWidth.value());
+    }
+    ID.AddInteger(TDMS->NoUniqueAddress);
+  } break;
+  case ReflectionKind::Annotation: {
+    appendSourceLocation(ID, APV.getReflectedAnnotation()->getEqLoc());
+  } break;
+  default:
+    llvm_unreachable("unknown reflection kind");
+  }
 }
 
 bool reflection_hash(APValue &Result, ASTContext &C, MetaActions &Meta,
@@ -6533,60 +6598,7 @@ bool reflection_hash(APValue &Result, ASTContext &C, MetaActions &Meta,
   }
 
   llvm::FoldingSetNodeID ID;
-  ID.AddInteger(static_cast<std::size_t>(R.getReflectionKind()));
-
-  switch (R.getReflectionKind()) {
-  case ReflectionKind::Null: {
-    ID.AddInteger(0);
-  } break;
-  case ReflectionKind::Type: {
-    appendQualType(ID, R.getReflectedType());
-  } break;
-  case ReflectionKind::Object: {
-    appendAPValue(C, ID, R.getReflectedObject());
-  } break;
-  case ReflectionKind::Value: {
-    appendAPValue(C, ID, R.getReflectedValue());
-  } break;
-  case ReflectionKind::Declaration: {
-    appendSourceRange(ID, R.getReflectedDecl()->getSourceRange());
-  } break;
-  case ReflectionKind::Template: {
-    appendSourceRange(ID, R.getReflectedTemplate().getAsTemplateDecl()->getSourceRange());
-  } break;
-  case ReflectionKind::Namespace: {
-    appendSourceRange(ID, R.getReflectedNamespace()->getSourceRange());
-  } break;
-  case ReflectionKind::EntityProxy: {
-    appendSourceLocation(ID, R.getReflectedEntityProxy()->getLocation());
-  } break;
-  case ReflectionKind::Parameter: {
-    appendSourceLocation(ID, R.getReflectedParameter()->getLocation());
-  } break;
-  case ReflectionKind::BaseSpecifier: {
-    appendSourceRange(ID, R.getReflectedBaseSpecifier()->getSourceRange());
-  } break;
-  case ReflectionKind::DataMemberSpec: {
-    TagDataMemberSpec *TDMS = R.getReflectedDataMemberSpec();
-    appendQualType(ID, TDMS->Ty);
-    if (TDMS->Name) {
-        ID.AddString(TDMS->Name.value());
-    }
-    if (TDMS->Alignment) {
-        ID.AddInteger(TDMS->Alignment.value());
-    }
-    if (TDMS->BitWidth) {
-        ID.AddInteger(TDMS->BitWidth.value());
-    }
-    ID.AddInteger(TDMS->NoUniqueAddress);
-  } break;
-  case ReflectionKind::Annotation: {
-    appendSourceLocation(ID, R.getReflectedAnnotation()->getEqLoc());
-  } break;
-  default:
-    llvm_unreachable("unknown reflection kind");
-  }
-
+  appendReflection(C, ID, R);
   return SetAndSucceed(
     Result,
     APValue(C.MakeIntValue(ID.computeStableHash(), C.getSizeType())));

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -6458,13 +6458,17 @@ bool reflection_hash(APValue &Result, ASTContext &C, MetaActions &Meta,
     val = 6;
     Decl* D = R.getReflectedNamespace();
     if (isa<TranslationUnitDecl>(D)) { // global namespace
-        ID.AddInteger(0);
-    }
-    else if (isa<NamespaceAliasDecl>(D)) {
-        ID.AddInteger(1);
+        ID.AddInteger(0); // nothing else to do
     }
     else if (isa<NamespaceDecl>(D)) {
-        ID.AddInteger(2);
+        NamespaceDecl* ND = dyn_cast<NamespaceDecl>(D);
+        SourceLocation loc = ND->getBeginLoc();
+        ID.AddInteger(loc.getHashValue());
+    }
+    else if (isa<NamespaceAliasDecl>(D)) {
+        NamespaceAliasDecl* ND = dyn_cast<NamespaceAliasDecl>(D);
+        SourceLocation loc = ND->getAliasLoc();
+        ID.AddInteger(loc.getHashValue());
     }
     else {
         llvm_unreachable("unhandled namespace kind");

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -6435,12 +6435,6 @@ bool reflection_hash(APValue &Result, ASTContext &C, MetaActions &Meta,
     return true;
   }
 
-  //llvm::FoldingSetNodeID ID;
-  //R.getReflectedType().Profile(ID);
-  //return SetAndSucceed(
-  //  Result,
-  //  APValue(C.MakeIntValue(ID.computeStableHash(), C.getSizeType())));
-
   // TODO(Matt): find difference between isReflectionType() and C.MetaInfoTy
   //assert(ResultTy == C.MetaInfoTy);
 
@@ -6490,21 +6484,23 @@ bool reflection_hash(APValue &Result, ASTContext &C, MetaActions &Meta,
   case ReflectionKind::BaseSpecifier: {                             // TODO
     seed = 7; 
   } break;
-  case ReflectionKind::DataMemberSpec: {                            // TODO
+  case ReflectionKind::DataMemberSpec: {                            // DONE
+  return SetAndSucceed(
+    Result,
+    APValue(C.MakeIntValue(1337, C.getSizeType())));
     seed = 8;
-    //TagDataMemberSpec *TDMS = RV.getReflectedDataMemberSpec();
-    // TODO: Add the QualType to the hash
-    // TDMS->Ty
-    //if (TDMS->Name) {
-    //    ID.AddString(TDMS->Name.value());
-    //}
-    //if (TDMS->Alignment) {
-    //    ID.AddInteger(TDMS->Alignment.value());
-    //}
-    //if (TDMS->BitWidth) {
-    //    ID.AddInteger(TDMS->BitWidth.value());
-    //}
-    //ID.AddInteger(TDMS->NoUniqueAddress);
+    TagDataMemberSpec *TDMS = R.getReflectedDataMemberSpec();
+    appendQualType(ID, TDMS->Ty);
+    if (TDMS->Name) {
+        ID.AddString(TDMS->Name.value());
+    }
+    if (TDMS->Alignment) {
+        ID.AddInteger(TDMS->Alignment.value());
+    }
+    if (TDMS->BitWidth) {
+        ID.AddInteger(TDMS->BitWidth.value());
+    }
+    ID.AddInteger(TDMS->NoUniqueAddress);
   } break;
   case ReflectionKind::Annotation: {                                // TODO
     seed = 9; 

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -6440,22 +6440,22 @@ bool reflection_hash(APValue &Result, ASTContext &C, MetaActions &Meta,
 
   llvm::FoldingSetNodeID ID;
 
-  std::size_t val = 0;
+  std::size_t seed = 0; // to distinguish hashes of different kinds
   switch (R.getReflectionKind()) {
   case ReflectionKind::Null:
-    val = 0; break;
+    seed = 0; break;
   case ReflectionKind::Type:
-    val = 1; break;
+    seed = 1; break;
   case ReflectionKind::Declaration:
-    val = 2; break;
+    seed = 2; break;
   case ReflectionKind::Object:
-    val = 3; break;
+    seed = 3; break;
   case ReflectionKind::Value:
-    val = 4; break;
+    seed = 4; break;
   case ReflectionKind::Template:
-    val = 5; break;
+    seed = 5; break;
   case ReflectionKind::Namespace: {
-    val = 6;
+    seed = 6;
     Decl* D = R.getReflectedNamespace();
     if (isa<TranslationUnitDecl>(D)) { // global namespace
         ID.AddInteger(0); // nothing else to do
@@ -6475,15 +6475,15 @@ bool reflection_hash(APValue &Result, ASTContext &C, MetaActions &Meta,
     }
   } break;
   case ReflectionKind::BaseSpecifier:
-    val = 7; break;
+    seed = 7; break;
   case ReflectionKind::DataMemberSpec:
-    val = 8; break;
+    seed = 8; break;
   case ReflectionKind::Annotation:
-    val = 9; break;
+    seed = 9; break;
   default:
     llvm_unreachable("unknown reflection kind");
   }
-  ID.AddInteger(val);
+  ID.AddInteger(seed);
   return SetAndSucceed(
     Result,
     APValue(C.MakeIntValue(ID.computeStableHash(), C.getSizeType())));

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -1676,6 +1676,7 @@ StringRef DescriptionOf(APValue RV, bool Granular = true) {
     return "an annotation";
   }
   }
+  return "unknown reflection";
 }
 
 bool DiagnoseReflectionKind(DiagFn Diagnoser, SourceRange Range,
@@ -6450,31 +6451,38 @@ bool reflection_hash(APValue &Result, ASTContext &C, MetaActions &Meta,
   ID.AddInteger(static_cast<std::size_t>(R.getReflectionKind()));
 
   switch (R.getReflectionKind()) {
-  case ReflectionKind::Null: {                                      // DONE
+  case ReflectionKind::Null: {
     ID.AddInteger(0);
   } break;
-  case ReflectionKind::Type: {                                      // DONE 
+  case ReflectionKind::Type: {
     appendQualType(ID, R.getReflectedType());
   } break;
-  case ReflectionKind::Declaration: {                               // DONE 
-    appendSourceRange(ID, R.getReflectedDecl()->getSourceRange());
-  } break;
-  case ReflectionKind::Object: {                                    // TODO
+  case ReflectionKind::Object: {
     llvm_unreachable("TODO - Object not yet hashable");
   } break;
-  case ReflectionKind::Value: {                                     // DONE
+  case ReflectionKind::Value: {
     R.getReflectedValue().Profile(ID);
-  break; }
-  case ReflectionKind::Template: {                                  // DONE
+    break; }
+  case ReflectionKind::Declaration: {
+      appendSourceRange(ID, R.getReflectedDecl()->getSourceRange());
+    } break;
+  case ReflectionKind::Template: {
     appendSourceRange(ID, R.getReflectedTemplate().getAsTemplateDecl()->getSourceRange());
   } break;
-  case ReflectionKind::Namespace: {                                 // DONE
+  case ReflectionKind::Namespace: {
     appendSourceRange(ID, R.getReflectedNamespace()->getSourceRange());
   } break;
-  case ReflectionKind::BaseSpecifier: {                             // DONE 
+  case ReflectionKind::EntityProxy: {
+    llvm_unreachable("TODO - EntityProxy not yet hashable");
+    appendSourceLocation(ID, R.getReflectedEntityProxy()->getLocation());
+  } break;
+  case ReflectionKind::Parameter: {
+    llvm_unreachable("TODO - Parameter not yet hashable");
+  } break;
+  case ReflectionKind::BaseSpecifier: {
     appendSourceRange(ID, R.getReflectedBaseSpecifier()->getSourceRange());
   } break;
-  case ReflectionKind::DataMemberSpec: {                            // DONE
+  case ReflectionKind::DataMemberSpec: {
     TagDataMemberSpec *TDMS = R.getReflectedDataMemberSpec();
     appendQualType(ID, TDMS->Ty);
     if (TDMS->Name) {
@@ -6488,7 +6496,7 @@ bool reflection_hash(APValue &Result, ASTContext &C, MetaActions &Meta,
     }
     ID.AddInteger(TDMS->NoUniqueAddress);
   } break;
-  case ReflectionKind::Annotation: {                                // DONE 
+  case ReflectionKind::Annotation: {
     appendSourceLocation(ID, R.getReflectedAnnotation()->getEqLoc());
   } break;
   default:

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -6484,7 +6484,7 @@ static void appendAPValue(ASTContext &C, llvm::FoldingSetNodeID &ID, const APVal
           APV.getComplexFloatImag().Profile(ID);
           APV.getComplexFloatReal().Profile(ID);
         } break;
-        case APValue::LValue: { // TODO: Fill this in
+        case APValue::LValue: {
           appendLValue(C, ID, APV);
         } break;
         case APValue::Vector: {

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -6429,11 +6429,43 @@ bool reflection_hash(APValue &Result, ASTContext &C, MetaActions &Meta,
     return true;
   }
 
-  llvm::FoldingSetNodeID ID;
-  R.getReflectedType().Profile(ID);
+  //llvm::FoldingSetNodeID ID;
+  //R.getReflectedType().Profile(ID);
+  //return SetAndSucceed(
+  //  Result,
+  //  APValue(C.MakeIntValue(ID.computeStableHash(), C.getSizeType())));
+
+  // TODO(Matt): find difference between isReflectionType() and C.MetaInfoTy
+  //assert(ResultTy == C.MetaInfoTy);
+
+  std::size_t val = 0;
+  switch (R.getReflectionKind()) {
+  case ReflectionKind::Null:
+    val = 0; break;
+  case ReflectionKind::Type:
+    val = 1; break;
+  case ReflectionKind::Declaration:
+    val = 2; break;
+  case ReflectionKind::Object:
+    val = 3; break;
+  case ReflectionKind::Value:
+    val = 4; break;
+  case ReflectionKind::Template:
+    val = 5; break;
+  case ReflectionKind::Namespace:
+    val = 6; break;
+  case ReflectionKind::BaseSpecifier:
+    val = 7; break;
+  case ReflectionKind::DataMemberSpec:
+    val = 8; break;
+  case ReflectionKind::Annotation:
+    val = 9; break;
+  default:
+    llvm_unreachable("unknown reflection kind");
+  }
   return SetAndSucceed(
     Result,
-    APValue(C.MakeIntValue(ID.ComputeHash(), C.getSizeType())));
+    APValue(C.MakeIntValue(val, C.getSizeType())));
 }
 
 }  // end namespace clang

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -6444,16 +6444,13 @@ static void appendAPValue(llvm::FoldingSetNodeID &ID, const APValue& APV)
           llvm_unreachable("Type of APValue not available at compile time");
         } break;
         case APValue::Int: {
-          auto I = APV.getInt();
-          I.Profile(ID);
+          APV.getInt().Profile(ID);
         } break;
         case APValue::Float: {
-          auto F = APV.getFloat();
-          F.Profile(ID);
+          APV.getFloat().Profile(ID);
         } break;
         case APValue::FixedPoint: {
-          auto F = APV.getFixedPoint();
-          llvm_unreachable("TODO: Hashing APValue::FixedPoint not implemented");
+          APV.getFixedPoint().getValue().Profile(ID);
         } break;
         case APValue::ComplexInt: {
           APV.getComplexIntImag().Profile(ID);
@@ -6472,6 +6469,7 @@ static void appendAPValue(llvm::FoldingSetNodeID &ID, const APValue& APV)
           }
         } break;
         case APValue::Array: {
+          llvm_unreachable("TODO: Hashing APValue::Array not implemented");
           for (std::size_t i = 0; i != APV.getArraySize(); ++i) {
             if (i < APV.getArrayInitializedElts()) {
               appendAPValue(ID, APV.getArrayInitializedElt(i));

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -6438,6 +6438,8 @@ bool reflection_hash(APValue &Result, ASTContext &C, MetaActions &Meta,
   // TODO(Matt): find difference between isReflectionType() and C.MetaInfoTy
   //assert(ResultTy == C.MetaInfoTy);
 
+  llvm::FoldingSetNodeID ID;
+
   std::size_t val = 0;
   switch (R.getReflectionKind()) {
   case ReflectionKind::Null:
@@ -6452,8 +6454,22 @@ bool reflection_hash(APValue &Result, ASTContext &C, MetaActions &Meta,
     val = 4; break;
   case ReflectionKind::Template:
     val = 5; break;
-  case ReflectionKind::Namespace:
-    val = 6; break;
+  case ReflectionKind::Namespace: {
+    val = 6;
+    Decl* D = R.getReflectedNamespace();
+    if (isa<TranslationUnitDecl>(D)) { // global namespace
+        ID.AddInteger(0);
+    }
+    else if (isa<NamespaceAliasDecl>(D)) {
+        ID.AddInteger(1);
+    }
+    else if (isa<NamespaceDecl>(D)) {
+        ID.AddInteger(2);
+    }
+    else {
+        llvm_unreachable("unhandled namespace kind");
+    }
+  } break;
   case ReflectionKind::BaseSpecifier:
     val = 7; break;
   case ReflectionKind::DataMemberSpec:
@@ -6463,9 +6479,10 @@ bool reflection_hash(APValue &Result, ASTContext &C, MetaActions &Meta,
   default:
     llvm_unreachable("unknown reflection kind");
   }
+  ID.AddInteger(val);
   return SetAndSucceed(
     Result,
-    APValue(C.MakeIntValue(val, C.getSizeType())));
+    APValue(C.MakeIntValue(ID.computeStableHash(), C.getSizeType())));
 }
 
 }  // end namespace clang

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -6435,6 +6435,73 @@ static void appendSourceRange(llvm::FoldingSetNodeID &ID, const SourceRange& Ran
     appendSourceLocation(ID, Range.getEnd());
 }
 
+static void appendAPValue(llvm::FoldingSetNodeID &ID, const APValue& APV)
+{
+    ID.AddInteger(APV.getKind());
+    switch (APV.getKind()) {
+        case APValue::None:
+        case APValue::Indeterminate: {
+          llvm_unreachable("Type of APValue not available at compile time");
+        } break;
+        case APValue::Int: {
+          auto I = APV.getInt();
+          I.Profile(ID);
+        } break;
+        case APValue::Float: {
+          auto F = APV.getFloat();
+          F.Profile(ID);
+        } break;
+        case APValue::FixedPoint: {
+          auto F = APV.getFixedPoint();
+          llvm_unreachable("TODO: Hashing APValue::FixedPoint not implemented");
+        } break;
+        case APValue::ComplexInt: {
+          APV.getComplexIntImag().Profile(ID);
+          APV.getComplexIntReal().Profile(ID);
+        } break;
+        case APValue::ComplexFloat: {
+          APV.getComplexFloatImag().Profile(ID);
+          APV.getComplexFloatReal().Profile(ID);
+        } break;
+        case APValue::LValue: {
+          llvm_unreachable("TODO: Hashing APValue::LValue not implemented");
+        } break;
+        case APValue::Vector: {
+          for (std::size_t i = 0; i != APV.getVectorLength(); ++i) {
+            appendAPValue(ID, APV.getVectorElt(i));
+          }
+        } break;
+        case APValue::Array: {
+          for (std::size_t i = 0; i != APV.getArraySize(); ++i) {
+            if (i < APV.getArrayInitializedElts()) {
+              appendAPValue(ID, APV.getArrayInitializedElt(i));
+            } else {
+              appendAPValue(ID, APV.getArrayFiller());
+            }
+          }
+        } break;
+        case APValue::Struct: {
+          llvm_unreachable("TODO: Hashing APValue::Struct not implemented");
+        } break;
+        case APValue::Union: {
+          llvm_unreachable("TODO: Hashing APValue::Union not implemented");
+        } break;
+        case APValue::MemberPointer: {
+          llvm_unreachable("TODO: Hashing APValue::MemberPointer not implemented");
+        } break;
+        case APValue::AddrLabelDiff: {
+          llvm_unreachable("TODO: Hashing APValue::AddrLabelDiff not implemented");
+        } break;
+        case APValue::Reflection: {
+          ID.AddInteger(1);
+          llvm_unreachable("TODO: Hashing APValue::Reflection not implemented");
+        } break;
+        default: {
+            llvm_unreachable("unknown ap value");
+        }
+    }
+}
+
 bool reflection_hash(APValue &Result, ASTContext &C, MetaActions &Meta,
                     EvalFn Evaluator, DiagFn Diagnoser, bool AllowInjection,
                     QualType ResultTy, SourceRange Range, ArrayRef<Expr *> Args,
@@ -6458,14 +6525,14 @@ bool reflection_hash(APValue &Result, ASTContext &C, MetaActions &Meta,
     appendQualType(ID, R.getReflectedType());
   } break;
   case ReflectionKind::Object: {
-    llvm_unreachable("TODO - Object not yet hashable");
+    appendAPValue(ID, R.getReflectedObject());
   } break;
   case ReflectionKind::Value: {
-    R.getReflectedValue().Profile(ID);
-    break; }
+    appendAPValue(ID, R.getReflectedValue());
+  } break;
   case ReflectionKind::Declaration: {
-      appendSourceRange(ID, R.getReflectedDecl()->getSourceRange());
-    } break;
+    appendSourceRange(ID, R.getReflectedDecl()->getSourceRange());
+  } break;
   case ReflectionKind::Template: {
     appendSourceRange(ID, R.getReflectedTemplate().getAsTemplateDecl()->getSourceRange());
   } break;

--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -5719,3 +5719,5 @@ HLSLAttributedResourceType::findHandleTypeOnResource(const Type *RT) {
   }
   return nullptr;
 }
+
+int Type::s_idCounter = 0;

--- a/libcxx/include/meta
+++ b/libcxx/include/meta
@@ -549,6 +549,8 @@ enum : unsigned {
   // Other bespoke functions (not proposed at this time)
   __metafn_is_access_specified,
   __metafn_reflect_invoke,
+
+  __metafn_reflection_hash,
 };
 
 consteval auto __workaround_expand_compiler_builtins(info type) -> info;
@@ -3022,6 +3024,27 @@ consteval auto u8display_string_of(info R) -> u8string_view {
 }
 
 _LIBCPP_END_NAMESPACE_REFLECTION_V2
+
+_LIBCPP_BEGIN_NAMESPACE_STD
+
+template <typename T> struct consteval_hash;
+
+template <>
+struct consteval_hash<meta::info>
+{
+  consteval consteval_hash() = default;
+  consteval consteval_hash(const consteval_hash&) = default;
+  consteval consteval_hash(consteval_hash&&) = default;
+  consteval auto operator()(meta::info r) const noexcept -> size_t
+  {
+    return __metafunction(meta::detail::__metafn_reflection_hash, r);
+  }
+
+private:
+  const meta::info unused = ^^::; // required to make type consteval-only
+};
+
+_LIBCPP_END_NAMESPACE_STD
 
 #endif  // __has_feature(reflection)
 


### PR DESCRIPTION
Implements https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3816r0.html in a way that is stable across repeated runs of the compiler on unchanged source code.

The simplest way to define the hash is to just hash the AST pointer that the given reflection represents, but this results in different hash values with each compilation run which is undesirable (the compiler should not introduce sources of instability, repeated compilations should yield the same result).

This implementation instead looks at what the reflection represents underneath and constructs a hash based on the value, resulting in hash values that are stable across repeated runs. Creating hashes for types in this way proved trickier, so this PR instead assigns a unique value to every type which gets for its hash value instead. These are defined in the order that the types are, so rearranging types in the source code can change the values, but they remain stable across repeat builds.

The obvious downside with this approach is that it needs to be updated whenever future standards introduce new constructs that can be reflected. A second approach can be found [here](https://github.com/bloomberg/clang-p2996/pull/195) which uses a way to generate a stable value from the underlying pointer AST which makes the implementation much simpler and does not need to be continuously updated with future standards.