### PR TITLE
Fix "return_type_of doesn't unwrap aliases"

### DIFF
--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -22,6 +22,7 @@
 #include "clang/AST/Metafunction.h"
 #include "clang/AST/RecordLayout.h"
 #include "clang/AST/Reflection.h"
+#include "clang/AST/Type.h"
 #include "clang/Basic/DiagnosticMetafn.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Lex/Lexer.h"
@@ -5605,7 +5606,9 @@ bool return_type_of(APValue &Result, ASTContext &C, MetaActions &Meta,
 
   switch (RV.getReflectionKind()) {
   case ReflectionKind::Type: {
-    if (auto *FPT = dyn_cast<FunctionProtoType>(RV.getReflectedType())) {
+    // Unwrap alias, Keep CV and Ref
+    QualType rawType = desugarType(RV.getReflectedType(), true, false, false);
+    if (auto *FPT = dyn_cast<FunctionProtoType>(rawType)) {
       QualType QT =
           desugarType(FPT->getReturnType(), /*UnwrapAliases=*/ true,
                       /*DropCV=*/false, /*DropRefs=*/false);


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #<number>*
https://github.com/bloomberg/clang-p2996/issues/186

**Describe your changes**
Desugar the argument passed to return_type_of

**Testing performed**
Pass https://godbolt.org/z/4srncPa7z locally

**Additional context**
Add any other context about your contribution here.
