### PR TITLE
Fix is_public and is_class_member for scoped/unscoped enum

### DIFF
--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -3328,9 +3328,27 @@ bool is_public(APValue &Result, ASTContext &C, MetaActions &Meta,
                EvalFn Evaluator, DiagFn Diagnoser, bool AllowInjection,
                QualType ResultTy, SourceRange Range, ArrayRef<Expr *> Args,
                Decl *ContainingDecl) {
-  return is_ACCESS<AS_public>(Result, C, Meta, Evaluator, Diagnoser,
-                              AllowInjection, ResultTy, Range, Args,
-                              ContainingDecl);
+
+  [[maybe_unused]] bool scratch
+    = is_class_member(Result, C, Meta, Evaluator, Diagnoser,
+                      AllowInjection, ResultTy, Range, Args,
+                      ContainingDecl);
+
+  if (const bool isClassMember = Result.getInt().getBoolValue();isClassMember) {
+    return is_ACCESS<AS_public>(Result, C, Meta, Evaluator, Diagnoser,
+                                AllowInjection, ResultTy, Range, Args,
+                                ContainingDecl);
+  }
+  // fallthrough: base-class relationship
+  scratch = is_base(Result, C, Meta, Evaluator, Diagnoser,
+                    AllowInjection, ResultTy, Range, Args,
+                    ContainingDecl);
+  if (const bool isBaseClass = Result.getInt().getBoolValue();isBaseClass) {
+    return is_ACCESS<AS_public>(Result, C, Meta, Evaluator, Diagnoser,
+                                AllowInjection, ResultTy, Range, Args,
+                                ContainingDecl);
+  }
+  return false;
 }
 
 bool is_protected(APValue &Result, ASTContext &C, MetaActions &Meta,
@@ -3890,7 +3908,6 @@ bool is_class_member(APValue &Result, ASTContext &C, MetaActions &Meta,
                      ArrayRef<Expr *> Args, Decl *ContainingDecl) {
   assert(Args[0]->getType()->isReflectionType());
   assert(ResultTy == C.BoolTy);
-
   APValue Scratch;
   bool result = false;
 
@@ -3898,8 +3915,15 @@ bool is_class_member(APValue &Result, ASTContext &C, MetaActions &Meta,
   if (!parent_of(Scratch, C, Meta, Evaluator, SwallowDiags, AllowInjection,
                  C.MetaInfoTy, Range, Args, ContainingDecl)) {
     assert(Scratch.isReflection());
-    result = Scratch.isReflectedType() &&
-             Scratch.getReflectedType()->isRecordType();
+    // For unscoped enumerators, parent_of will return its enumeration type
+    // We need now to lookup context on that type
+    if (Scratch.isReflectedType() && Scratch.getReflectedType()->isUnscopedEnumerationType()) {
+      Decl *D = findTypeDecl(Scratch.getReflectedType());
+      result = D && D->getDeclContext() && D->getDeclContext()->isRecord();
+    } else {
+      result = Scratch.isReflectedType() &&
+              Scratch.getReflectedType()->isRecordType();
+    }
   }
   return SetAndSucceed(Result, makeBool(C, result));
 }

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -3324,18 +3324,19 @@ bool is_ACCESS(APValue &Result, ASTContext &C, MetaActions &Meta,
   llvm_unreachable("invalid reflection type");
 }
 
-bool is_public(APValue &Result, ASTContext &C, MetaActions &Meta,
+template <AccessSpecifier AS>
+static inline
+bool is_ClassMember_ACCESS(APValue &Result, ASTContext &C, MetaActions &Meta,
                EvalFn Evaluator, DiagFn Diagnoser, bool AllowInjection,
                QualType ResultTy, SourceRange Range, ArrayRef<Expr *> Args,
                Decl *ContainingDecl) {
-
   [[maybe_unused]] bool scratch
     = is_class_member(Result, C, Meta, Evaluator, Diagnoser,
                       AllowInjection, ResultTy, Range, Args,
                       ContainingDecl);
 
   if (const bool isClassMember = Result.getInt().getBoolValue();isClassMember) {
-    return is_ACCESS<AS_public>(Result, C, Meta, Evaluator, Diagnoser,
+    return is_ACCESS<AS>(Result, C, Meta, Evaluator, Diagnoser,
                                 AllowInjection, ResultTy, Range, Args,
                                 ContainingDecl);
   }
@@ -3344,29 +3345,41 @@ bool is_public(APValue &Result, ASTContext &C, MetaActions &Meta,
                     AllowInjection, ResultTy, Range, Args,
                     ContainingDecl);
   if (const bool isBaseClass = Result.getInt().getBoolValue();isBaseClass) {
-    return is_ACCESS<AS_public>(Result, C, Meta, Evaluator, Diagnoser,
+    return is_ACCESS<AS>(Result, C, Meta, Evaluator, Diagnoser,
                                 AllowInjection, ResultTy, Range, Args,
                                 ContainingDecl);
   }
   return false;
 }
 
+bool is_public(APValue &Result, ASTContext &C, MetaActions &Meta,
+               EvalFn Evaluator, DiagFn Diagnoser, bool AllowInjection,
+               QualType ResultTy, SourceRange Range, ArrayRef<Expr *> Args,
+               Decl *ContainingDecl) {
+    return is_ClassMember_ACCESS<AS_public>(
+      Result, C, Meta, Evaluator, Diagnoser,
+      AllowInjection, ResultTy, Range, Args,
+      ContainingDecl);
+}
+
 bool is_protected(APValue &Result, ASTContext &C, MetaActions &Meta,
                   EvalFn Evaluator, DiagFn Diagnoser, bool AllowInjection,
                   QualType ResultTy, SourceRange Range, ArrayRef<Expr *> Args,
                   Decl *ContainingDecl) {
-  return is_ACCESS<AS_protected>(Result, C, Meta, Evaluator, Diagnoser,
-                                 AllowInjection, ResultTy, Range, Args,
-                                 ContainingDecl);
+  return is_ClassMember_ACCESS<AS_protected>(
+    Result, C, Meta, Evaluator, Diagnoser,
+    AllowInjection, ResultTy, Range, Args,
+    ContainingDecl);
 }
 
 bool is_private(APValue &Result, ASTContext &C, MetaActions &Meta,
                 EvalFn Evaluator, DiagFn Diagnoser, bool AllowInjection,
                 QualType ResultTy, SourceRange Range, ArrayRef<Expr *> Args,
                 Decl *ContainingDecl) {
-  return is_ACCESS<AS_private>(Result, C, Meta, Evaluator, Diagnoser,
-                               AllowInjection, ResultTy, Range, Args,
-                               ContainingDecl);
+  return is_ClassMember_ACCESS<AS_private>(
+    Result, C, Meta, Evaluator, Diagnoser,
+    AllowInjection, ResultTy, Range, Args,
+    ContainingDecl);
 }
 
 bool is_virtual(APValue &Result, ASTContext &C, MetaActions &Meta,

--- a/libcxx/modules/std.cppm.in
+++ b/libcxx/modules/std.cppm.in
@@ -82,6 +82,7 @@ module;
 #include <mdspan>
 #include <memory>
 #include <memory_resource>
+#include <meta>
 #include <mutex>
 #include <new>
 #include <numbers>

--- a/libcxx/test/std/experimental/reflection/member-visibility.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/member-visibility.pass.cpp
@@ -392,4 +392,33 @@ struct D : A, protected B, private C {
 
 }  // namespace bb_clang_p2996_issue_148_regression_test
 
+                  // ========================================
+                  // bb_clang_p2996_issue_193_regression_test
+                  // ========================================
+
+namespace bb_clang_p2996_issue_193_regression_test {
+struct S {
+    enum E {
+        A
+    };
+
+    enum class SE {
+        B
+    };
+};
+
+static_assert(std::meta::is_class_member(^^S::E));
+static_assert(std::meta::is_class_member(^^S::SE));
+
+static_assert(std::meta::is_public(^^S::E));
+static_assert(std::meta::is_public(^^S::SE));
+
+static_assert(std::meta::is_class_member(^^S::E::A));
+static_assert(!std::meta::is_class_member(^^S::SE::B));
+
+static_assert(std::meta::is_public(^^S::E::A));
+static_assert(!std::meta::is_public(^^S::SE::B));
+
+}  // namespace bb_clang_p2996_issue_193_regression_test
+
 int main() { }

--- a/libcxx/utils/ci/run-buildbot
+++ b/libcxx/utils/ci/run-buildbot
@@ -282,6 +282,8 @@ check-generated-output)
            --exclude 'ostream.pass.cpp' \
            --exclude 'transcoding.pass.cpp' \
            --exclude 'underflow.pass.cpp' \
+           --exclude 'define-aggregate.pass.cpp' \
+           --exclude 'names.pass.cpp' \
            || false
 ;;
 #


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #193*

**Describe your changes**
- is_class_member: When looking at an unscoped enum, the first lookup of context find the enum type which isnt a record, we then need to lookup at the context of that type to find out whether it s hosted in a record.
- is_private/is_public/is_protected: Only enforce whether the access level is the one we specify, not whether it's a class member or not, so this again goes wrong with enum. This time scoped...
- Some regression tests are failing: update those.

**Testing performed**
Add problematic test in our regression cases

**Additional context**
Add any other context about your contribution here.
