### PR TITLE
Fix `is_noexcept` for  implicit noexcept destructors when marked as default or deleted

### DIFF
--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -1481,13 +1481,12 @@ static bool isFunctionOrMethodNoexcept(const QualType QT) {
   if (T->isFunctionProtoType()) {
     // This covers (virtual) methods & functions
     const auto *FPT = T->getAs<FunctionProtoType>();
-
     switch (FPT->getExceptionSpecType()) {
-    case EST_BasicNoexcept:
-    case EST_NoexceptTrue:
-      return true;
-    default:
-      return false;
+      case EST_BasicNoexcept:
+      case EST_NoexceptTrue:
+        return true;
+      default:
+        return false;
     }
   }
 

--- a/clang/lib/Sema/SemaReflect.cpp
+++ b/clang/lib/Sema/SemaReflect.cpp
@@ -349,7 +349,13 @@ public:
 
   void EnsureInstantiationOfExceptionSpec(SourceLocation Loc,
                                           FunctionDecl *FD) override {
-    S.InstantiateExceptionSpec(Loc, FD);
+    const FunctionProtoType *Proto = FD->getType()->castAs<FunctionProtoType>();
+    if (Proto->getExceptionSpecType() == EST_Uninstantiated) {
+      S.InstantiateExceptionSpec(Loc, FD);
+    }
+    if (Proto->getExceptionSpecType() == EST_Unevaluated) {
+      S.ResolveExceptionSpec(Loc, Proto);
+    }
   }
 
   QualType Substitute(TypeAliasTemplateDecl *TD,

--- a/libcxx/test/std/experimental/reflection/member-classification.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/member-classification.pass.cpp
@@ -703,6 +703,16 @@ static_assert(!is_noexcept(type_of(^^EC::Something)));
 static_assert(!is_noexcept(^^E));
 static_assert(!is_noexcept(^^E_Something));
 static_assert(!is_noexcept(type_of(^^E_Something)));
+
+// Defaulted special members
+struct T { ~T() = delete; };
+static_assert(is_noexcept (^^T::~T));
+
+struct U { ~U() = default; };
+static_assert(is_noexcept (^^U::~U));
+
+struct W { };
+static_assert(is_noexcept (^^W::~W));
 } // namespace noexcept_functions
 
                               // ================

--- a/libcxx/test/std/experimental/reflection/member-classification.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/member-classification.pass.cpp
@@ -705,14 +705,14 @@ static_assert(!is_noexcept(^^E_Something));
 static_assert(!is_noexcept(type_of(^^E_Something)));
 
 // Defaulted special members
-struct TT { ~TT() = delete; };
-static_assert(is_noexcept (^^TT::~TT));
+struct DelDest { ~DelDest() = delete; };
+static_assert(is_noexcept (^^DelDest::~DelDest));
 
-struct U { ~U() = default; };
-static_assert(is_noexcept (^^U::~U));
+struct DefDest { ~DefDest() = default; };
+static_assert(is_noexcept (^^DefDest::~DefDest));
 
-struct W { };
-static_assert(is_noexcept (^^W::~W));
+struct EmptyStruct { };
+static_assert(is_noexcept (^^EmptyStruct::~EmptyStruct));
 } // namespace noexcept_functions
 
                               // ================

--- a/libcxx/test/std/experimental/reflection/member-classification.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/member-classification.pass.cpp
@@ -705,8 +705,8 @@ static_assert(!is_noexcept(^^E_Something));
 static_assert(!is_noexcept(type_of(^^E_Something)));
 
 // Defaulted special members
-struct T { ~T() = delete; };
-static_assert(is_noexcept (^^T::~T));
+struct TT { ~TT() = delete; };
+static_assert(is_noexcept (^^TT::~TT));
 
 struct U { ~U() = default; };
 static_assert(is_noexcept (^^U::~U));


### PR DESCRIPTION
Fix #192 

**Describe your changes**
Trigger evaluation of exception specifier when lazily left unevaluated

_For symmetry with the template instantiation case, and ease of reading, I have also hoisted back the check on `EST_Uninstantiated` even though it's also done inside `InstantiateExceptionSpec` (ie it's redundant)_

**Testing performed**
No-regression test cases added, problematic cases all passing.

**Additional context**
Add any other context about your contribution here.
