### PR TITLE
Cherrypicked 3 commits from upstream that fixes compile errors on Windows

### DIFF
--- a/lldb/include/lldb/Host/windows/MainLoopWindows.h
+++ b/lldb/include/lldb/Host/windows/MainLoopWindows.h
@@ -17,6 +17,8 @@
 
 namespace lldb_private {
 
+using handle_t = void *;
+
 // Windows-specific implementation of the MainLoopBase class. It can monitor
 // socket descriptors for readability using WSAEventSelect. Non-socket file
 // descriptors are not supported.
@@ -33,15 +35,15 @@ public:
 
   class IOEvent {
   public:
-    IOEvent(IOObject::WaitableHandle event) : m_event(event) {}
+    IOEvent(handle_t event) : m_event(event) {}
     virtual ~IOEvent() {}
     virtual void WillPoll() {}
     virtual void DidPoll() {}
     virtual void Disarm() {}
-    IOObject::WaitableHandle GetHandle() { return m_event; }
+    handle_t GetHandle() { return m_event; }
 
   protected:
-    IOObject::WaitableHandle m_event;
+    handle_t m_event;
   };
   using IOEventUP = std::unique_ptr<IOEvent>;
 

--- a/lldb/include/lldb/lldb-types.h
+++ b/lldb/include/lldb/lldb-types.h
@@ -42,11 +42,14 @@ typedef void *rwlock_t;
 typedef void *process_t;                          // Process type is HANDLE
 typedef void *thread_t;                           // Host thread type
 typedef void *file_t;                             // Host file type
-typedef unsigned int __w64 socket_t;              // Host socket type
+typedef uintptr_t socket_t;                       // Host socket type
 typedef void *thread_arg_t;                       // Host thread argument type
 typedef unsigned thread_result_t;                 // Host thread result type
 typedef thread_result_t (*thread_func_t)(void *); // Host thread function type
 typedef void *pipe_t;                             // Host pipe type is HANDLE
+
+// printf macro for file_t
+#define PRIuFT PRIuPTR
 
 #else
 
@@ -62,6 +65,9 @@ typedef void *thread_arg_t;             // Host thread argument type
 typedef void *thread_result_t;          // Host thread result type
 typedef void *(*thread_func_t)(void *); // Host thread function type
 typedef int pipe_t;                     // Host pipe type
+
+// printf macro for file_t
+#define PRIuFT PRIi32
 
 #endif // _WIN32
 

--- a/lldb/include/lldb/lldb-types.h
+++ b/lldb/include/lldb/lldb-types.h
@@ -48,9 +48,6 @@ typedef unsigned thread_result_t;                 // Host thread result type
 typedef thread_result_t (*thread_func_t)(void *); // Host thread function type
 typedef void *pipe_t;                             // Host pipe type is HANDLE
 
-// printf macro for file_t
-#define PRIuFT PRIuPTR
-
 #else
 
 #include <pthread.h>
@@ -65,9 +62,6 @@ typedef void *thread_arg_t;             // Host thread argument type
 typedef void *thread_result_t;          // Host thread result type
 typedef void *(*thread_func_t)(void *); // Host thread function type
 typedef int pipe_t;                     // Host pipe type
-
-// printf macro for file_t
-#define PRIuFT PRIi32
 
 #endif // _WIN32
 

--- a/lldb/source/Host/common/JSONTransport.cpp
+++ b/lldb/source/Host/common/JSONTransport.cpp
@@ -42,7 +42,8 @@ ReadFull(IOObject &descriptor, size_t length,
   if (timeout && timeout_supported) {
     SelectHelper sh;
     sh.SetTimeout(*timeout);
-    sh.FDSetRead((lldb::socket_t)descriptor.GetWaitableHandle());
+    sh.FDSetRead(
+        reinterpret_cast<lldb::socket_t>(descriptor.GetWaitableHandle()));
     Status status = sh.Select();
     if (status.Fail()) {
       // Convert timeouts into a specific error.

--- a/lldb/source/Host/posix/ConnectionFileDescriptorPosix.cpp
+++ b/lldb/source/Host/posix/ConnectionFileDescriptorPosix.cpp
@@ -272,13 +272,11 @@ size_t ConnectionFileDescriptor::Read(void *dst, size_t dst_len,
   error = m_io_sp->Read(dst, bytes_read);
 
   if (log) {
-    LLDB_LOGF(log,
-              "%p ConnectionFileDescriptor::Read()  fd = %" PRIuFT
-              ", dst = %p, dst_len = %" PRIu64 ") => %" PRIu64 ", error = %s",
-              static_cast<void *>(this),
-              static_cast<file_t>(m_io_sp->GetWaitableHandle()),
-              static_cast<void *>(dst), static_cast<uint64_t>(dst_len),
-              static_cast<uint64_t>(bytes_read), error.AsCString());
+    LLDB_LOG(log,
+             "{0} ConnectionFileDescriptor::Read()  fd = {1}"
+             ", dst = {2}, dst_len = {3}) => {4}, error = {5}",
+             this, m_io_sp->GetWaitableHandle(), dst, dst_len, bytes_read,
+             error.AsCString());
   }
 
   if (bytes_read == 0) {
@@ -376,13 +374,11 @@ size_t ConnectionFileDescriptor::Write(const void *src, size_t src_len,
   error = m_io_sp->Write(src, bytes_sent);
 
   if (log) {
-    LLDB_LOGF(log,
-              "%p ConnectionFileDescriptor::Write(fd = %" PRIuFT
-              ", src = %p, src_len = %" PRIu64 ") => %" PRIu64 " (error = %s)",
-              static_cast<void *>(this),
-              static_cast<file_t>(m_io_sp->GetWaitableHandle()),
-              static_cast<const void *>(src), static_cast<uint64_t>(src_len),
-              static_cast<uint64_t>(bytes_sent), error.AsCString());
+    LLDB_LOG(log,
+             "{0} ConnectionFileDescriptor::Write(fd = {1}"
+             ", src = {2}, src_len = {3}) => {4} (error = {5})",
+             this, m_io_sp->GetWaitableHandle(), src, src_len, bytes_sent,
+             error.AsCString());
   }
 
   if (error_ptr)

--- a/lldb/source/Host/posix/ConnectionFileDescriptorPosix.cpp
+++ b/lldb/source/Host/posix/ConnectionFileDescriptorPosix.cpp
@@ -273,10 +273,10 @@ size_t ConnectionFileDescriptor::Read(void *dst, size_t dst_len,
 
   if (log) {
     LLDB_LOGF(log,
-              "%p ConnectionFileDescriptor::Read()  fd = %" PRIu64
+              "%p ConnectionFileDescriptor::Read()  fd = %" PRIuFT
               ", dst = %p, dst_len = %" PRIu64 ") => %" PRIu64 ", error = %s",
               static_cast<void *>(this),
-              static_cast<uint64_t>(m_io_sp->GetWaitableHandle()),
+              static_cast<file_t>(m_io_sp->GetWaitableHandle()),
               static_cast<void *>(dst), static_cast<uint64_t>(dst_len),
               static_cast<uint64_t>(bytes_read), error.AsCString());
   }
@@ -377,10 +377,10 @@ size_t ConnectionFileDescriptor::Write(const void *src, size_t src_len,
 
   if (log) {
     LLDB_LOGF(log,
-              "%p ConnectionFileDescriptor::Write(fd = %" PRIu64
+              "%p ConnectionFileDescriptor::Write(fd = %" PRIuFT
               ", src = %p, src_len = %" PRIu64 ") => %" PRIu64 " (error = %s)",
               static_cast<void *>(this),
-              static_cast<uint64_t>(m_io_sp->GetWaitableHandle()),
+              static_cast<file_t>(m_io_sp->GetWaitableHandle()),
               static_cast<const void *>(src), static_cast<uint64_t>(src_len),
               static_cast<uint64_t>(bytes_sent), error.AsCString());
   }
@@ -452,7 +452,7 @@ ConnectionFileDescriptor::BytesAvailable(const Timeout<std::micro> &timeout,
       select_helper.SetTimeout(*timeout);
 
     // FIXME: Migrate to MainLoop.
-    select_helper.FDSetRead((lldb::socket_t)handle);
+    select_helper.FDSetRead(reinterpret_cast<socket_t>(handle));
 #if defined(_WIN32)
     // select() won't accept pipes on Windows.  The entire Windows codepath
     // needs to be converted over to using WaitForMultipleObjects and event

--- a/lldb/source/Host/windows/MainLoopWindows.cpp
+++ b/lldb/source/Host/windows/MainLoopWindows.cpp
@@ -9,6 +9,7 @@
 #include "lldb/Host/windows/MainLoopWindows.h"
 #include "lldb/Host/Config.h"
 #include "lldb/Host/Socket.h"
+#include "lldb/Host/windows/windows.h"
 #include "lldb/Utility/Status.h"
 #include "llvm/Config/llvm-config.h"
 #include "llvm/Support/Casting.h"
@@ -18,6 +19,8 @@
 #include <cerrno>
 #include <csignal>
 #include <ctime>
+#include <io.h>
+#include <thread>
 #include <vector>
 #include <winsock2.h>
 
@@ -39,9 +42,8 @@ namespace {
 class PipeEvent : public MainLoopWindows::IOEvent {
 public:
   explicit PipeEvent(HANDLE handle)
-      : IOEvent((IOObject::WaitableHandle)CreateEventW(
-            NULL, /*bManualReset=*/FALSE,
-            /*bInitialState=*/FALSE, NULL)),
+      : IOEvent(CreateEventW(NULL, /*bManualReset=*/FALSE,
+                             /*bInitialState=*/FALSE, NULL)),
         m_handle(handle), m_ready(CreateEventW(NULL, /*bManualReset=*/FALSE,
                                                /*bInitialState=*/FALSE, NULL)) {
     assert(m_event && m_ready);
@@ -53,12 +55,12 @@ public:
       SetEvent(m_ready);
       // Keep trying to cancel ReadFile() until the thread exits.
       do {
-        CancelIoEx((HANDLE)m_handle, /*lpOverlapped=*/NULL);
+        CancelIoEx(m_handle, /*lpOverlapped=*/NULL);
       } while (WaitForSingleObject(m_monitor_thread.native_handle(), 1) ==
                WAIT_TIMEOUT);
       m_monitor_thread.join();
     }
-    CloseHandle((HANDLE)m_event);
+    CloseHandle(m_event);
     CloseHandle(m_ready);
   }
 
@@ -107,7 +109,7 @@ public:
         continue;
       }
 
-      SetEvent((HANDLE)m_event);
+      SetEvent(m_event);
 
       // Wait until the current read is consumed before doing the next read.
       WaitForSingleObject(m_ready, INFINITE);
@@ -124,15 +126,15 @@ private:
 class SocketEvent : public MainLoopWindows::IOEvent {
 public:
   explicit SocketEvent(SOCKET socket)
-      : IOEvent((IOObject::WaitableHandle)WSACreateEvent()), m_socket(socket) {
+      : IOEvent(WSACreateEvent()), m_socket(socket) {
     assert(m_event != WSA_INVALID_EVENT);
   }
 
-  ~SocketEvent() override { WSACloseEvent((HANDLE)m_event); }
+  ~SocketEvent() override { WSACloseEvent(m_event); }
 
   void WillPoll() {
-    int result = WSAEventSelect(m_socket, (HANDLE)m_event,
-                                FD_READ | FD_ACCEPT | FD_CLOSE);
+    int result =
+        WSAEventSelect(m_socket, m_event, FD_READ | FD_ACCEPT | FD_CLOSE);
     assert(result == 0);
     UNUSED_IF_ASSERT_DISABLED(result);
   }
@@ -143,7 +145,7 @@ public:
     UNUSED_IF_ASSERT_DISABLED(result);
   }
 
-  void Disarm() override { WSAResetEvent((HANDLE)m_event); }
+  void Disarm() override { WSAResetEvent(m_event); }
 
   SOCKET m_socket;
 };
@@ -167,7 +169,7 @@ llvm::Expected<size_t> MainLoopWindows::Poll() {
   events.reserve(m_read_fds.size() + 1);
   for (auto &[_, fd_info] : m_read_fds) {
     fd_info.event->WillPoll();
-    events.push_back((HANDLE)fd_info.event->GetHandle());
+    events.push_back(fd_info.event->GetHandle());
   }
   events.push_back(m_interrupt_event);
 
@@ -206,16 +208,21 @@ MainLoopWindows::RegisterReadObject(const IOObjectSP &object_sp,
     return nullptr;
   }
 
-  if (object_sp->GetFdType() == IOObject::eFDTypeSocket)
+  if (object_sp->GetFdType() == IOObject::eFDTypeSocket) {
     m_read_fds[waitable_handle] = {
-        std::make_unique<SocketEvent>((SOCKET)waitable_handle), callback};
-  else if (GetFileType(waitable_handle) == FILE_TYPE_PIPE)
-    m_read_fds[waitable_handle] = {
-        std::make_unique<PipeEvent>((HANDLE)waitable_handle), callback};
-  else {
-    error = Status::FromErrorStringWithFormat("Unsupported file type %d",
-                                              GetFileType(waitable_handle));
-    return nullptr;
+        std::make_unique<SocketEvent>(
+            reinterpret_cast<SOCKET>(waitable_handle)),
+        callback};
+  } else {
+    DWORD file_type = GetFileType(waitable_handle);
+    if (file_type != FILE_TYPE_PIPE) {
+      error = Status::FromErrorStringWithFormat("Unsupported file type %d",
+                                                file_type);
+      return nullptr;
+    }
+
+    m_read_fds[waitable_handle] = {std::make_unique<PipeEvent>(waitable_handle),
+                                   callback};
   }
 
   return CreateReadHandle(object_sp);

--- a/lldb/source/Utility/SelectHelper.cpp
+++ b/lldb/source/Utility/SelectHelper.cpp
@@ -177,7 +177,7 @@ lldb_private::Status SelectHelper::Select() {
 #endif
   // Set the FD bits in the fdsets for read/write/error
   for (auto &pair : m_fd_map) {
-    const lldb::socket_t fd = pair.first;
+    lldb::socket_t fd = pair.first;
 
     if (pair.second.read_set)
       FD_SET(fd, read_fdset_ptr);

--- a/llvm/include/llvm/ADT/Hashing.h
+++ b/llvm/include/llvm/ADT/Hashing.h
@@ -136,7 +136,7 @@ namespace detail {
 
 inline uint64_t fetch64(const char *p) {
   uint64_t result;
-  memcpy(&result, p, sizeof(result));
+  std::memcpy(&result, p, sizeof(result));
   if (sys::IsBigEndianHost)
     sys::swapByteOrder(result);
   return result;
@@ -144,7 +144,7 @@ inline uint64_t fetch64(const char *p) {
 
 inline uint32_t fetch32(const char *p) {
   uint32_t result;
-  memcpy(&result, p, sizeof(result));
+  std::memcpy(&result, p, sizeof(result));
   if (sys::IsBigEndianHost)
     sys::swapByteOrder(result);
   return result;
@@ -379,7 +379,7 @@ bool store_and_advance(char *&buffer_ptr, char *buffer_end, const T& value,
   if (buffer_ptr + store_size > buffer_end)
     return false;
   const char *value_data = reinterpret_cast<const char *>(&value);
-  memcpy(buffer_ptr, value_data + offset, store_size);
+  std::memcpy(buffer_ptr, value_data + offset, store_size);
   buffer_ptr += store_size;
   return true;
 }
@@ -513,7 +513,7 @@ public:
       // with the variadic combine because that formation can have varying
       // argument types.
       size_t partial_store_size = buffer_end - buffer_ptr;
-      memcpy(buffer_ptr, &data, partial_store_size);
+      std::memcpy(buffer_ptr, &data, partial_store_size);
 
       // If the store fails, our buffer is full and ready to hash. We have to
       // either initialize the hash state (on the first full buffer) or mix

--- a/llvm/include/llvm/ADT/SmallVector.h
+++ b/llvm/include/llvm/ADT/SmallVector.h
@@ -518,7 +518,7 @@ protected:
     // use memcpy here. Note that I and E are iterators and thus might be
     // invalid for memcpy if they are equal.
     if (I != E)
-      memcpy(reinterpret_cast<void *>(Dest), I, (E - I) * sizeof(T));
+      std::memcpy(reinterpret_cast<void *>(Dest), I, (E - I) * sizeof(T));
   }
 
   /// Double the size of the allocated memory, guaranteeing space for at
@@ -561,7 +561,7 @@ protected:
 public:
   void push_back(ValueParamT Elt) {
     const T *EltPtr = reserveForParamAndGetAddress(Elt);
-    memcpy(reinterpret_cast<void *>(this->end()), EltPtr, sizeof(T));
+    std::memcpy(reinterpret_cast<void *>(this->end()), EltPtr, sizeof(T));
     this->set_size(this->size() + 1);
   }
 


### PR DESCRIPTION
**Describe your changes**

Cherrypicked 3 commits which fixed building on Windows from LLVM upstream. These three commits fix compilation errors on Windows without having to perform a full merge from the upstream:

- 43f3312b	[lldb] Remove PRIuFT macro and use LLDB_LOG instead (#146867)...	david.spickett@linaro.org	07/03/2025 22:30:39
- 86b1677b	[lldb] Fixing warnings / win32 builds in MainLoop. (#146632)...	harjohn@google.com	07/03/2025 03:49:19
- f6eed167	[ADT] Avoid ambiguity by using std::memcpy instead of memcpy (NFC).	akuegel@google.com	07/14/2025 16:47:08

**Testing performed**
Compiled successfully.