### PR TITLE
Handle Splice and SpliceWithTemplate switch cases & fix `TypeSystemClang::CreateBaseClassSpecifier` not compiling

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/UseDefaultMemberInitCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseDefaultMemberInitCheck.cpp
@@ -29,6 +29,9 @@ static StringRef getValueOfValueInit(const QualType InitType) {
   case Type::STK_MemberPointer:
     return "nullptr";
 
+  case Type::STK_Reflection:
+    return "{}";
+
   case Type::STK_Bool:
     return "false";
 

--- a/clang-tools-extra/clangd/CodeComplete.cpp
+++ b/clang-tools-extra/clangd/CodeComplete.cpp
@@ -1477,6 +1477,10 @@ bool allowIndex(CodeCompletionContext &CC) {
   // Unresolved inside a template.
   case NestedNameSpecifier::Identifier:
     return false;
+  // I don't think these should be indexed for code completion.
+  case NestedNameSpecifier::Splice:
+  case NestedNameSpecifier::SpliceWithTemplate:
+    return false;
   }
   llvm_unreachable("invalid NestedNameSpecifier kind");
 }

--- a/clang-tools-extra/clangd/DumpAST.cpp
+++ b/clang-tools-extra/clangd/DumpAST.cpp
@@ -159,6 +159,8 @@ class DumpVisitor : public RecursiveASTVisitor<DumpVisitor> {
       NNS_KIND(Global);
       NNS_KIND(Super);
       NNS_KIND(NamespaceAlias);
+      NNS_KIND(Splice);
+      NNS_KIND(SpliceWithTemplate);
 #undef NNS_KIND
     }
     llvm_unreachable("Unhandled SpecifierKind enum");

--- a/clang-tools-extra/clangd/FindTarget.cpp
+++ b/clang-tools-extra/clangd/FindTarget.cpp
@@ -508,6 +508,10 @@ public:
     case NestedNameSpecifier::Super:
       add(NNS->getAsRecordDecl(), Flags);
       return;
+    // todo: not handled yet
+    case NestedNameSpecifier::Splice:
+    case NestedNameSpecifier::SpliceWithTemplate:
+      return;
     }
     llvm_unreachable("unhandled NestedNameSpecifier::SpecifierKind");
   }

--- a/clang/include/clang/AST/AbstractBasicReader.h
+++ b/clang/include/clang/AST/AbstractBasicReader.h
@@ -292,6 +292,7 @@ public:
         continue;
 
       case NestedNameSpecifier::Splice:
+      case NestedNameSpecifier::SpliceWithTemplate:
         cur = NestedNameSpecifier::SpliceScopeSpecifier(ctx,
                                             asImpl().readBool(),
                                             asImpl().readSpliceSpecifierRef());

--- a/clang/include/clang/AST/AbstractBasicWriter.h
+++ b/clang/include/clang/AST/AbstractBasicWriter.h
@@ -271,6 +271,7 @@ public:
         continue;
 
       case NestedNameSpecifier::Splice:
+      case NestedNameSpecifier::SpliceWithTemplate:
         asImpl().writeSpliceSpecifierRef(NNS->getAsSplice());
         continue;
       }

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -13894,6 +13894,11 @@ static NestedNameSpecifier *getCommonNNS(ASTContext &Ctx,
     assert(K2 == NestedNameSpecifier::SpecifierKind::Global &&
            "Global NNS cannot be equivalent to any other kind");
     llvm_unreachable("Global NestedNameSpecifiers did not compare equal");
+
+  // todo unhandled
+  case NestedNameSpecifier::SpecifierKind::Splice:
+  case NestedNameSpecifier::SpecifierKind::SpliceWithTemplate:
+    break;
   }
   assert(Ctx.getCanonicalNestedNameSpecifier(R) == Canon);
   return R;

--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -9876,6 +9876,7 @@ ASTImporter::Import(NestedNameSpecifier *FromNNS) {
     }
 
   case NestedNameSpecifier::Splice:
+  case NestedNameSpecifier::SpliceWithTemplate:
     llvm_unreachable("unimplemented");
   }
 

--- a/clang/lib/AST/NestedNameSpecifier.cpp
+++ b/clang/lib/AST/NestedNameSpecifier.cpp
@@ -319,6 +319,8 @@ NestedNameSpecifier::translateToType(const ASTContext &Context) const {
   case SpecifierKind::Namespace:
   case SpecifierKind::NamespaceAlias:
   case SpecifierKind::Super:
+  case SpecifierKind::Splice:
+  case SpecifierKind::SpliceWithTemplate:
     // These are not representable as types.
     return nullptr;
   }

--- a/clang/lib/AST/ODRHash.cpp
+++ b/clang/lib/AST/ODRHash.cpp
@@ -136,6 +136,7 @@ void ODRHash::AddNestedNameSpecifier(const NestedNameSpecifier *NNS) {
   case NestedNameSpecifier::Global:
   case NestedNameSpecifier::Super:
   case NestedNameSpecifier::Splice:  // TODO(P2996): This is wrong.
+  case NestedNameSpecifier::SpliceWithTemplate:
     break;
   }
 }

--- a/clang/lib/AST/QualTypeNames.cpp
+++ b/clang/lib/AST/QualTypeNames.cpp
@@ -254,6 +254,10 @@ static NestedNameSpecifier *getFullyQualifiedNestedNameSpecifier(
       }
       return Scope;
     }
+    // todo unhandled
+    case NestedNameSpecifier::Splice:
+    case NestedNameSpecifier::SpliceWithTemplate:
+      break;
   }
   llvm_unreachable("bad NNS kind");
 }

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -4261,8 +4261,10 @@ TypeSystemClang::GetTypeClass(lldb::opaque_compiler_type_t type) {
     break;
   case clang::Type::HLSLInlineSpirv:
     break;
+  case clang::Type::ReflectionSplice:
+    break;
   }
-  // We don't know hot to display this type...
+  // We don't know how to display this type...
   return lldb::eTypeClassOther;
 }
 
@@ -5047,6 +5049,9 @@ lldb::Encoding TypeSystemClang::GetEncoding(lldb::opaque_compiler_type_t type,
     case clang::BuiltinType::UnresolvedTemplate:
       break;
 
+    case clang::BuiltinType::MetaInfo:
+      break;
+
     // AMD GPU builtin types.
 #define AMDGPU_TYPE(Name, Id, SingletonId, Width, Align)                       \
   case clang::BuiltinType::Id:
@@ -5129,6 +5134,10 @@ lldb::Encoding TypeSystemClang::GetEncoding(lldb::opaque_compiler_type_t type,
   case clang::Type::HLSLAttributedResource:
     break;
   case clang::Type::HLSLInlineSpirv:
+    break;
+
+  // todo
+  case clang::Type::ReflectionSplice:
     break;
   }
   count = 0;
@@ -5296,8 +5305,11 @@ lldb::Format TypeSystemClang::GetFormat(lldb::opaque_compiler_type_t type) {
     break;
   case clang::Type::HLSLInlineSpirv:
     break;
+
+  case clang::Type::ReflectionSplice:
+    break;
   }
-  // We don't know hot to display this type...
+  // We don't know how to display this type...
   return lldb::eFormatBytes;
 }
 
@@ -7860,9 +7872,10 @@ TypeSystemClang::CreateBaseClassSpecifier(lldb::opaque_compiler_type_t type,
     return nullptr;
 
   return std::make_unique<clang::CXXBaseSpecifier>(
-      clang::SourceRange(), is_virtual, base_of_class,
+      clang::SourceRange(), is_virtual, /*base_of_class,*/
       TypeSystemClang::ConvertAccessTypeToAccessSpecifier(access),
       getASTContext().getTrivialTypeSourceInfo(GetQualType(type)),
+      GetAsCXXRecordDecl(type),
       clang::SourceLocation());
 }
 


### PR DESCRIPTION
- Just for the sake of completeness, I have added some switch cases not handled (mainly `Splice` and `SpliceWithTemplate`). I believe these additional lines won't change the current behaviors of the compiler (at least I didn't spot any). But they suppress compiler warnings and I added `// todo` comments to them. ... And two typo inherited from upstream.
- Also fixed a weird inconsistency in `TypeSystemClang::CreateBaseClassSpecifier`, causing the file to not compile (it tries to make_unique a `clang::CXXBaseSpecifier` with a signature from the future. Idk why.)

I think these lines of change are benign. If you also think so, maybe consider reviewing this draft. Thanks.