### PR TITLE
fix Sema::BuildCXXReflectExpr wrongly thinks a template is overloaded when it fails to deduce a temp variable's type made from it. e.g. when reflecting `^^decltype([](this auto &&) { })::operator()`

### DIFF
--- a/clang/lib/Sema/SemaReflect.cpp
+++ b/clang/lib/Sema/SemaReflect.cpp
@@ -1259,6 +1259,39 @@ ExprResult Sema::BuildCXXReflectExpr(SourceLocation OperatorLoc,
 
   // Use the 'auto' deduction machinery to infer the operand type.
   if (DeduceVariableDeclarationType(InventedVD, true, ULE)) {
+    // If auto-deduction failed, it's likely because the ULE refers to a
+    // raw Template (which cannot initialize 'auto'), but IS valid to reflect.
+    // e.g. function template with deduced this.
+    // Also generalize for ANY template type (Function, Var, Class, Alias, etc.)
+
+    TemplateDecl *UniqueTemplate = nullptr;
+    bool IsAmbiguous = false;
+
+    for (NamedDecl *D : ULE->decls()) {
+      D = D->getUnderlyingDecl();
+
+      // Use TemplateDecl to cover Function, Var, Class, Alias, Concepts
+      if (auto *TD = dyn_cast<TemplateDecl>(D)) {
+        if (!UniqueTemplate) {
+          UniqueTemplate = TD;
+        } else if (UniqueTemplate != TD) {
+          IsAmbiguous = true;
+          break;
+        }
+      } else {
+        // Found something that isn't a template (e.g. a regular function).
+        // Mixing templates and non-templates is ambiguous for reflection.
+        IsAmbiguous = true;
+        break;
+      }
+    }
+
+    if (UniqueTemplate && !IsAmbiguous) {
+      // It is a unique Template. Break.
+      return BuildCXXReflectExpr(OperatorLoc, E->getExprLoc(),
+                                 TemplateName(UniqueTemplate));
+    }
+
     Diag(E->getExprLoc(), diag::err_reflect_overload_set)
         << E->getSourceRange();
     return ExprError();


### PR DESCRIPTION
Test code

Fixes https://github.com/bloomberg/clang-p2996/issues/239

Or you can simply pull from https://github.com/UsagiEngine/buildsystem-llvm-project/tree/yukino-dev-reflection which contains the merge made in https://github.com/bloomberg/clang-p2996/pull/243

```cpp
#include <meta>

namespace tests
{
// =============================================================================
// Helpers
// =============================================================================

template <auto>
struct probe
{
};

// Concept to check if an expression is a valid reflection
template <std::meta::info Refl>
concept CanReflect = requires { typename probe<Refl>; };

// =============================================================================
// Test Case 1: Standard Functions (Baseline)
// =============================================================================

void func_unique(int)
{
}

void func_overloaded(int)
{
}

void func_overloaded(float)
{
}

static_assert(CanReflect<^^func_unique>, "Should reflect unique function");
static_assert(
    !CanReflect<^^func_overloaded>,
    "Should REJECT ambiguous function overload set"
);

// =============================================================================
// Test Case 2: Function Templates (The Main Fix)
// =============================================================================

template <typename T>
void tpl_unique(T)
{
}

template <typename T>
void tpl_overloaded(T)
{
}

template <typename T>
void tpl_overloaded(T, T)
{
} // Arity overload

// NOTE: P2996 allows reflecting a Template Name.
// ^^tpl_unique should work (it is a single TemplateDecl).
static_assert(
    CanReflect<^^tpl_unique>, "Should reflect unique function template"
);

// ^^tpl_overloaded is strictly ambiguous because there are TWO TemplateDecls.
// Your fix correctly loops and sees (UniqueTemplate != D), setting
// IsAmbiguous=true.
static_assert(
    !CanReflect<^^tpl_overloaded>,
    "Should REJECT ambiguous template overload set"
);

// =============================================================================
// Test Case 3: Deduced This Lambdas (The Original Crash)
// =============================================================================

consteval bool test_deduced_this()
{
    auto l  = [](this auto && self) { };
    using L = decltype(l);

    // This previously crashed or errored with "overload set".
    // Now it should resolve to the single FunctionTemplateDecl of the operator.
    constexpr auto r = ^^L::operator();

    return std::meta::is_template(r);
}

static_assert(
    test_deduced_this(), "Should reflect deduced-this operator as a Template"
);

// =============================================================================
// Test Case 4: Variable Templates (Generalized Fix)
// =============================================================================

template <typename T>
constexpr int var_tpl_unique = 0;

template <typename T>
constexpr int var_tpl_overloaded = 1;

// "Overloading" variable templates isn't really possible in the same scope
// without partial specialization (which is the SAME decl), but let's test
// the basic unique case which failed auto-deduction before.
static_assert(CanReflect<^^var_tpl_unique>, "Should reflect variable template");

// =============================================================================
// Test Case 5: Mixed Sets (Template + Non-Template)
// =============================================================================

void mixed_set()
{
}

template <typename T>
void mixed_set(T)
{
}

// This is ambiguous: one FunctionDecl and one FunctionTemplateDecl.
// Your fix handles this in the `else` block (IsAmbiguous = true).
static_assert(
    !CanReflect<^^mixed_set>, "Should REJECT mixed set of function and template"
);

// =============================================================================
// Test Case 6: SFINAE Robustness (No Crashing)
// =============================================================================

// This concept checks if we can "extract" the operator() from a type.
// It crashed previously because the lookup inside the requires-expression was a
// hard error.
template <typename T>
concept HasReflectableOperator = requires { typename probe<^^T::operator()>; };

auto l_simple  = []() { };
auto l_deduced = [](this auto &&) { };

static_assert(HasReflectableOperator<decltype(l_simple)>, "Simple lambda");
static_assert(
    HasReflectableOperator<decltype(l_deduced)>,
    "Deduced-this lambda (Fix verification)"
);

struct NoOp
{
};

static_assert(
    !HasReflectableOperator<NoOp>, "No operator() -> SFINAE failure (not crash)"
);

// =============================================================================
// SFINAE Utils
// =============================================================================

// This concept checks if `^^T::name` is a valid expression.
// If the compiler emits "overload set" error, this concept simply returns false
// (Substitution Failure) instead of halting compilation.

template <typename T>
concept CanReflectMemberF = requires { ^^T::f; };

template <typename T>
concept CanReflectMemberG = requires { ^^T::g; };

// =============================================================================
// Test Subjects
// =============================================================================

struct DeducedThisSimple
{
    // Single member function template (deduced this)
    // PRE-FIX: Failed (UnresolvedLookupExpr -> Error)
    // POST-FIX: Should Pass (UnresolvedLookupExpr -> Template)
    constexpr void f(this auto && self) { }
};

struct DeducedThisOverloaded
{
    // Genuine ambiguity (two templates)
    constexpr void g(this auto && self) { }

    constexpr void g(this auto && self, int) { }
};

struct MixedMember
{
    // Genuine ambiguity (function + template)
    void g() { }

    void g(this auto && self) { }
};

// =============================================================================
// Validation
// =============================================================================

// 1. Deduced This Member (Unique)
// This proves your fix works for class members, not just lambdas.
static_assert(
    CanReflectMemberF<DeducedThisSimple>,
    "FAIL: Could not reflect unique deduced-this member!"
);

// Verify we can actually use the result
constexpr auto r_deduced = ^^DeducedThisSimple::f;
static_assert(std::meta::is_function_template(r_deduced));
static_assert(std::meta::identifier_of(r_deduced) == "f");

// 2. Deduced This Member (Ambiguous)
// This proves your fix didn't break legitimate overload detection.
static_assert(
    !CanReflectMemberG<DeducedThisOverloaded>,
    "FAIL: Should have rejected overloaded deduced-this members"
);

// 3. Mixed Set Member
static_assert(
    !CanReflectMemberG<MixedMember>,
    "FAIL: Should have rejected mixed member set"
);
} // namespace tests
```