### PR TITLE
Prevent annotation on alias declaration type-specifier

### DIFF
--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -1804,6 +1804,8 @@ def err_expansion_statements_disabled : Error<
   "'template for' statements are not enabled; use '-fexpansion-statements'">;
 def err_annotation_with_using : Error<
   "annotations are not permitted following an attribute-using-prefix">;
+def err_annotation_used_on : Error<
+  "annotations are not permitted on %select{using directives}0">;
 def err_mixed_attributes_and_annotations : Error<
   "attribute specifier cannot contain both attributes and annotations">;
 def warn_meant_parenthesize_reflection : Warning<

--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -1805,7 +1805,7 @@ def err_expansion_statements_disabled : Error<
 def err_annotation_with_using : Error<
   "annotations are not permitted following an attribute-using-prefix">;
 def err_annotation_used_on : Error<
-  "annotations are not permitted on %select{using directives}0">;
+  "annotations are not permitted on %select{defining-type-id}0">;
 def err_mixed_attributes_and_annotations : Error<
   "attribute specifier cannot contain both attributes and annotations">;
 def warn_meant_parenthesize_reflection : Warning<

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -1128,6 +1128,9 @@ private:
   ///@{
 
 private:
+  /// Flag whether we are inside a using-declaration.
+  bool InUsingDeclaration;
+
   struct ParsingClass;
 
   /// [class.mem]p1: "... the class is regarded as complete within

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -673,10 +673,6 @@ Parser::DeclGroupPtrTy Parser::ParseUsingDeclaration(
     SourceLocation UsingLoc, SourceLocation &DeclEnd,
     ParsedAttributes &PrefixAttrs, AccessSpecifier AS) {
   SourceLocation UELoc;
-  // Flag to the parser we are parsing a using declaration, among others we
-  // wanto to disallow annotations as valid here.
-  llvm::SaveAndRestore<bool> InInitStatementGuard(InUsingDeclaration, true);
-
   bool InInitStatement = Context == DeclaratorContext::SelectionInit ||
                          Context == DeclaratorContext::ForInit;
 
@@ -835,6 +831,10 @@ Parser::DeclGroupPtrTy Parser::ParseUsingDeclaration(
         << FixItHint::CreateRemoval(Range);
     Attrs.takeAllFrom(MisplacedAttrs);
   }
+
+  // Flag to the parser we are parsing a using declaration, among others we
+  // wanto to disallow parsing annotations as valid here.
+  llvm::SaveAndRestore<bool> InInitStatementGuard(InUsingDeclaration, true);
 
   // Maybe this is an alias-declaration.
   if (Tok.is(tok::equal) || InInitStatement) {

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -31,6 +31,7 @@
 #include "clang/Sema/Scope.h"
 #include "clang/Sema/SemaCodeCompletion.h"
 #include "clang/Sema/SemaHLSL.h"
+#include "llvm/Support/SaveAndRestore.h"
 #include "llvm/Support/TimeProfiler.h"
 #include <optional>
 
@@ -672,6 +673,10 @@ Parser::DeclGroupPtrTy Parser::ParseUsingDeclaration(
     SourceLocation UsingLoc, SourceLocation &DeclEnd,
     ParsedAttributes &PrefixAttrs, AccessSpecifier AS) {
   SourceLocation UELoc;
+  // Flag to the parser we are parsing a using declaration, among others we
+  // wanto to disallow annotations as valid here.
+  llvm::SaveAndRestore<bool> InInitStatementGuard(InUsingDeclaration, true);
+
   bool InInitStatement = Context == DeclaratorContext::SelectionInit ||
                          Context == DeclaratorContext::ForInit;
 
@@ -4839,7 +4844,11 @@ void Parser::ParseCXX11AttributeSpecifierInternal(ParsedAttributes &Attrs,
         if (CommonScopeName) {
           Diag(Tok.getLocation(), diag::err_annotation_with_using);
           SkipUntil(tok::r_square, tok::colon, tok::r_splice, StopBeforeMatch);
-        } else {
+        } else if (InUsingDeclaration) {
+          Diag(Tok.getLocation(), diag::err_annotation_used_on) << 0;
+          SkipUntil(tok::r_square, tok::colon, tok::r_splice, StopBeforeMatch);
+        }
+         else {
           ParseAnnotationSpecifier(Attrs, EndLoc);
         }
         continue;

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -56,10 +56,10 @@ IdentifierInfo *Parser::getSEHExceptKeyword() {
 }
 
 Parser::Parser(Preprocessor &pp, Sema &actions, bool skipFunctionBodies)
-    : PP(pp),
+    :  PP(pp),
       PreferredType(&actions.getASTContext(), pp.isCodeCompletionEnabled()),
       Actions(actions), Diags(PP.getDiagnostics()), StackHandler(Diags),
-      GreaterThanIsOperator(true), ColonIsSacred(false),
+      InUsingDeclaration(false), GreaterThanIsOperator(true), ColonIsSacred(false),
       InMessageExpression(false), ParsingInObjCContainer(false),
       TemplateParameterDepth(0) {
   SkipFunctionBodies = pp.isCodeCompletionEnabled() || skipFunctionBodies;

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -56,7 +56,7 @@ IdentifierInfo *Parser::getSEHExceptKeyword() {
 }
 
 Parser::Parser(Preprocessor &pp, Sema &actions, bool skipFunctionBodies)
-    :  PP(pp),
+    : PP(pp),
       PreferredType(&actions.getASTContext(), pp.isCodeCompletionEnabled()),
       Actions(actions), Diags(PP.getDiagnostics()), StackHandler(Diags),
       InUsingDeclaration(false), GreaterThanIsOperator(true), ColonIsSacred(false),

--- a/libcxx/test/std/experimental/reflection/annotations-regression.verify.cpp
+++ b/libcxx/test/std/experimental/reflection/annotations-regression.verify.cpp
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright 2024 Bloomberg Finance L.P.
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03 || c++11 || c++14 || c++17 || c++20
+// ADDITIONAL_COMPILE_FLAGS: -freflection-latest
+// <experimental/reflection>
+//
+// [reflection]
+
+#include <meta>
+
+                  // ========================================
+                  // bb_clang_p2996_issue_241_regression_test
+                  // ========================================
+
+namespace bb_clang_p2996_issue_241_regression_test {
+using F1 [[=1]] = int ;
+static_assert(std::meta::annotations_of(^^F1).size() == 1);
+
+using [[=1]] F2 = int ;  // expected-error {{an attribute list cannot appear here}}
+static_assert(std::meta::annotations_of(^^F2).size() == 1);
+
+struct Bar {};
+using F3 [[=1]] = [[=2]] Bar ;  // expected-error {{annotations are not permitted on defining-type-id}}
+static_assert(std::meta::annotations_of(^^F3).size() == 1);
+static_assert(std::meta::annotations_of(^^Bar).size() == 0);
+
+using F4 = [[=1]] int ;  // expected-error {{annotations are not permitted on defining-type-id}} // expected-error {{an attribute list cannot appear here}}
+static_assert(std::meta::annotations_of(^^F4).size() == 0);
+using F5 = int [[=1]];  // expected-error {{annotations are not permitted on defining-type-id}}
+static_assert(std::meta::annotations_of(^^F5).size() == 0);
+
+}  // namespace bb_clang_p2996_issue_241_regression_test
+
+int main() {}


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #<number>*
#241 

**Describe your changes**
Set flag in parser that we are parsing a using declaration, to refuse parsing annotation later on in an alias declaration parsing. 
Not great IMO,  when coming up with upstream design will need something more lightweight (touching `Parser.cpp` for a dedicated bool feels off...)

**Testing performed**
Reproduce problematic case
```
[100%] Building CXX object CMakeFiles/main.dir/main.cpp.o
main.cpp:3:19: error: annotations are not permitted on using directives
    3 | using foo = int [[=1]];
      |                   ^
```
Adding reg test

**Additional context**
Annotation in this branch are somewhat more lax than expected, work is underway at https://github.com/llvm/llvm-project/pull/166287 to provide an alternative
