### PR TITLE
BUG: Lambda capture within expansion statements

### DIFF
--- a/clang/include/clang/AST/DeclCXX.h
+++ b/clang/include/clang/AST/DeclCXX.h
@@ -1567,10 +1567,13 @@ public:
   /// If the class is a local class [class.local], returns
   /// the enclosing function declaration.
   const FunctionDecl *isLocalClass() const {
-    if (const auto *RD = dyn_cast<CXXRecordDecl>(getDeclContext()))
+    const DeclContext *DC = getDeclContext();
+    while (DC->getDeclKind() == Decl::ExpansionStmt)
+      DC = DC->getParent();
+    if (const auto *RD = dyn_cast<CXXRecordDecl>(DC))
       return RD->isLocalClass();
 
-    return dyn_cast<FunctionDecl>(getDeclContext());
+    return dyn_cast<FunctionDecl>(DC);
   }
 
   FunctionDecl *isLocalClass() {

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -15415,6 +15415,23 @@ private:
 
   bool IsSynthesizingExpansionStmt = false;
 
+public:
+  bool isSynthesizingExpansionStmt() const { return IsSynthesizingExpansionStmt; }
+
+  class ExpansionStmtSynthesisRAII {
+    Sema &S;
+    bool OldValue;
+  public:
+    ExpansionStmtSynthesisRAII(Sema &S, bool Enable = true)
+        : S(S), OldValue(S.IsSynthesizingExpansionStmt) {
+      S.IsSynthesizingExpansionStmt = Enable;
+    }
+    ~ExpansionStmtSynthesisRAII() {
+      S.IsSynthesizingExpansionStmt = OldValue;
+    }
+  };
+
+private:
   ///@}
 
   //

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -2555,8 +2555,6 @@ LambdaScopeInfo *Sema::getCurLambda(bool IgnoreNonLambdaCapturingScope) {
   auto *CurLSI = dyn_cast<LambdaScopeInfo>(*I);
   if (CurLSI && CurLSI->Lambda && CurLSI->CallOperator &&
       !CurLSI->Lambda->Encloses(CurContext) && CurLSI->AfterParameterList) {
-    // We have switched contexts due to template instantiation.
-    assert(!CodeSynthesisContexts.empty());
     return nullptr;
   }
 

--- a/clang/lib/Sema/SemaExpand.cpp
+++ b/clang/lib/Sema/SemaExpand.cpp
@@ -559,7 +559,7 @@ StmtResult Sema::FinishCXXExpansionStmt(Stmt *Heading, Stmt *Body) {
   while (Instantiations.size() < Expansion->getNumInstantiations()) {
 
     ContextRAII CtxGuard(*this, DC, /*NewThis=*/false);
-    auto guard = llvm::SaveAndRestore(IsSynthesizingExpansionStmt, !DC->isDependentContext());
+    ExpansionStmtSynthesisRAII ExpansionGuard(*this, !DC->isDependentContext());
 
     TemplateArgument TArgs[] = {
         { Context, llvm::APSInt::get(Instantiations.size()),

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -18817,6 +18817,9 @@ static DeclContext *getParentOfCapturingContextOrNull(DeclContext *DC,
   if (isa<BlockDecl>(DC) || isa<CapturedDecl>(DC) || isLambdaCallOperator(DC))
     return getLambdaAwareParentOfDeclContext(DC);
 
+  if (isa<ExpansionStmtDecl>(DC))
+    return DC->getParent();
+
   VarDecl *Underlying = Var->getPotentiallyDecomposedVarDecl();
   if (Underlying) {
     if (Underlying->hasLocalStorage() && Diagnose)
@@ -19281,6 +19284,8 @@ bool Sema::tryCaptureVariable(
            "FunctionScopes.");
     while (FSIndex != MaxFunctionScopesIndex) {
       DC = getLambdaAwareParentOfDeclContext(DC);
+      while (isa<ExpansionStmtDecl>(DC))
+        DC = DC->getParent();
       --FSIndex;
     }
   }
@@ -19346,7 +19351,18 @@ bool Sema::tryCaptureVariable(
         FunctionScopesIndex = MaxFunctionScopesIndex - 1;
         break;
       }
+      // If we've reached the variable's declaration context, we're done
+      // traversing. This can happen when traversing through expansion statements.
+      if (VarDC->Equals(DC))
+        break;
       return true;
+    }
+
+    // Expansion statements are DeclContexts but don't have FunctionScopeInfo
+    // entries. Just traverse through them.
+    if (isa<ExpansionStmtDecl>(DC)) {
+      DC = ParentDC;
+      continue;
     }
 
     FunctionScopeInfo  *FSI = FunctionScopes[FunctionScopesIndex];
@@ -19370,14 +19386,24 @@ bool Sema::tryCaptureVariable(
     // we do not want to capture new variables.  What was captured
     // during either a lambdas transformation or initial parsing
     // should be used.
-    if (isGenericLambdaCallOperatorSpecialization(DC)) {
+    // Exception: During expansion statement synthesis, we're creating fresh
+    // lambdas and should allow new captures.
+    if (isGenericLambdaCallOperatorSpecialization(DC) &&
+        !IsSynthesizingExpansionStmt) {
+      // Check if already captured in the lambda class - if so, we're good.
+      CXXRecordDecl *LambdaClass = cast<CXXMethodDecl>(DC)->getParent();
+      for (const LambdaCapture &Cap : LambdaClass->captures()) {
+        if (Cap.capturesVariable() && Cap.getCapturedVar() == Var)
+          return false;
+      }
       if (BuildAndDiagnose) {
-        LambdaScopeInfo *LSI = cast<LambdaScopeInfo>(CSI);
-        if (LSI->ImpCaptureStyle == CapturingScopeInfo::ImpCap_None) {
+        LambdaScopeInfo *LSI = dyn_cast<LambdaScopeInfo>(CSI);
+        if (LSI && LSI->ImpCaptureStyle == CapturingScopeInfo::ImpCap_None) {
           Diag(ExprLoc, diag::err_lambda_impcap) << Var;
           Diag(Var->getLocation(), diag::note_previous_decl) << Var;
-          Diag(LSI->Lambda->getBeginLoc(), diag::note_lambda_decl);
-          buildLambdaCaptureFixit(*this, LSI, Var);
+          Diag(LambdaClass->getBeginLoc(), diag::note_lambda_decl);
+          if (LSI)
+            buildLambdaCaptureFixit(*this, LSI, Var);
         } else
           diagnoseUncapturableValueReferenceOrBinding(*this, ExprLoc, Var);
       }
@@ -20040,6 +20066,13 @@ static void DoMarkPotentialCapture(Sema &SemaRef, SourceLocation Loc,
   }
 }
 
+static bool isDeclaredInExpansionStmtDecl(const Decl *D) {
+  for (const DeclContext *DC = D->getDeclContext(); DC; DC = DC->getParent())
+    if (isa<ExpansionStmtDecl>(DC))
+      return true;
+  return false;
+}
+
 static void DoMarkVarDeclReferenced(
     Sema &SemaRef, SourceLocation Loc, VarDecl *Var, Expr *E,
     llvm::DenseMap<const VarDecl *, int> &RefsMinusAssignments) {
@@ -20201,9 +20234,14 @@ static void DoMarkVarDeclReferenced(
 
   case OdrUseContext::Used:
     // If we might later find that this expression isn't actually an odr-use,
-    // delay the marking.
-    if (E && Var->isUsableInConstantExpressions(SemaRef.Context))
+    // delay the marking. But during expansion statement synthesis, we need
+    // immediate capture so lambda closures are properly constructed.
+    if (E && Var->isUsableInConstantExpressions(SemaRef.Context) &&
+        !SemaRef.isSynthesizingExpansionStmt())
       SemaRef.MaybeODRUseExprs.insert(E);
+    else if (SemaRef.isSynthesizingExpansionStmt() &&
+             isDeclaredInExpansionStmtDecl(Var))
+      Var->markUsed(SemaRef.Context);
     else
       MarkVarDeclODRUsed(Var, Loc, SemaRef);
     break;
@@ -20213,7 +20251,15 @@ static void DoMarkVarDeclReferenced(
     // odr-used, but we may still need to track them for lambda capture.
     // FIXME: Do we also need to do this inside dependent typeid expressions
     // (which are modeled as unevaluated at this point)?
-    DoMarkPotentialCapture(SemaRef, Loc, Var, E);
+    // During expansion statement synthesis, we need immediate capture so
+    // lambda closures are properly constructed.
+    if (SemaRef.isSynthesizingExpansionStmt() &&
+        isDeclaredInExpansionStmtDecl(Var))
+      Var->markUsed(SemaRef.Context);
+    else if (SemaRef.isSynthesizingExpansionStmt())
+      MarkVarDeclODRUsed(Var, Loc, SemaRef);
+    else
+      DoMarkPotentialCapture(SemaRef, Loc, Var, E);
     break;
   }
 }

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -7733,11 +7733,12 @@ ExprResult Sema::ActOnFinishFullExpr(Expr *FE, SourceLocation CC,
   //  - Teach the handful of places that iterate over FunctionScopes to
   //    stop at the outermost enclosing lexical scope."
   DeclContext *DC = CurContext;
-  while (isa_and_nonnull<CapturedDecl>(DC))
+  while (isa_and_nonnull<CapturedDecl>(DC) || isa_and_nonnull<ExpansionStmtDecl>(DC))
     DC = DC->getParent();
   const bool IsInLambdaDeclContext = isLambdaCallOperator(DC);
-  if (!IsSynthesizingExpansionStmt && IsInLambdaDeclContext && CurrentLSI &&
-      CurrentLSI->hasPotentialCaptures() && !FullExpr.isInvalid())
+  if (IsInLambdaDeclContext && CurrentLSI &&
+      CurrentLSI->hasPotentialCaptures() && !FullExpr.isInvalid() &&
+      !IsSynthesizingExpansionStmt)
     CheckIfAnyEnclosingLambdasMustCaptureAnyPotentialCaptures(FE, CurrentLSI,
                                                               *this);
   return MaybeCreateExprWithCleanups(FullExpr);

--- a/clang/lib/Sema/SemaLambda.cpp
+++ b/clang/lib/Sema/SemaLambda.cpp
@@ -74,6 +74,15 @@ static DeclContext *ignoreExpansionStmts(DeclContext *DC) {
   return DC;
 }
 
+static bool isInExpansionStmt(DeclContext *DC) {
+  while (DC && !DC->isTranslationUnit()) {
+    if (isa<ExpansionStmtDecl>(DC))
+      return true;
+    DC = DC->getParent();
+  }
+  return false;
+}
+
 static inline UnsignedOrNone getStackIndexOfNearestEnclosingCaptureReadyLambda(
     ArrayRef<const clang::sema::FunctionScopeInfo *> FunctionScopes,
     ValueDecl *VarToCapture) {
@@ -200,9 +209,10 @@ UnsignedOrNone clang::getStackIndexOfNearestEnclosingCaptureCapableLambda(
 
   const unsigned IndexOfCaptureReadyLambda = *OptionalStackIndex;
   assert(((IndexOfCaptureReadyLambda != (FunctionScopes.size() - 1)) ||
-          S.getCurGenericLambda()) &&
+          S.getCurGenericLambda() ||
+          isInExpansionStmt(S.CurContext)) &&
          "The capture ready lambda for a potential capture can only be the "
-         "current lambda if it is a generic lambda");
+         "current lambda if it is a generic lambda or inside an expansion statement");
 
   const sema::LambdaScopeInfo *const CaptureReadyLambdaLSI =
       cast<sema::LambdaScopeInfo>(FunctionScopes[IndexOfCaptureReadyLambda]);

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -2087,6 +2087,7 @@ Decl *TemplateDeclInstantiator::VisitExpansionStmtDecl(ExpansionStmtDecl *D) {
   // Enter the scope of this instantiation. We don't use
   // PushDeclContext because we don't have a scope.
   Sema::ContextRAII savedContext(SemaRef, Result, /*NewThis=*/false);
+  Sema::ExpansionStmtSynthesisRAII ExpansionGuard(SemaRef);
 
   StmtResult SR = SemaRef.SubstStmt(OldStmt, TemplateArgs);
   if (SR.isInvalid())

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -13511,12 +13511,24 @@ TreeTransform<Derived>::TransformDeclRefExpr(DeclRefExpr *E) {
       return ExprError();
   }
 
+  auto NeedsRebuildForExpansion = [&]() {
+    if (!SemaRef.isSynthesizingExpansionStmt())
+      return false;
+    auto *VD = dyn_cast<VarDecl>(ND);
+    if (!VD || !VD->hasLocalStorage())
+      return false;
+    for (auto *DC = VD->getDeclContext(); DC; DC = DC->getParent())
+      if (isa<ExpansionStmtDecl>(DC))
+        return false;
+    return true;
+  };
   if (!getDerived().AlwaysRebuild() &&
       !E->isCapturedByCopyInLambdaWithExplicitObjectParameter() &&
       QualifierLoc == E->getQualifierLoc() && ND == E->getDecl() &&
       Found == E->getFoundDecl() &&
       NameInfo.getName() == E->getDecl()->getDeclName() &&
-      !E->hasExplicitTemplateArgs()) {
+      !E->hasExplicitTemplateArgs() &&
+      !NeedsRebuildForExpansion()) {
     // Mark it referenced in the new context regardless.
     // FIXME: this is a bit instantiation-specific.
     SemaRef.MarkDeclRefReferenced(E);

--- a/clang/test/SemaCXX/cxx2c-expansion-stmts.cpp
+++ b/clang/test/SemaCXX/cxx2c-expansion-stmts.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// RUN: %clang_cc1 %s -std=c++26 -fexpansion-statements
+// RUN: %clang_cc1 %s -std=c++26 -fexpansion-statements -Wno-unused-value -verify
 
 
                           // ================
@@ -331,7 +331,7 @@ namespace destructurable_by_reference {
 
 consteval int fn() {
   struct S { int a; int b; int c; };
-  
+
   S s = {1, 2, 3};
   template for (auto m : s) m *= 2;
   template for (auto &m : s) m *= 2;
@@ -373,3 +373,34 @@ constexpr bool testIssue209() {
 }
 
 static_assert(testIssue209());
+
+// classes inside of expansion statements are still local
+auto some_function() -> void {
+  template for (constexpr int I : {0}) {
+    struct S {
+      static constexpr int value = 42; // expected-error {{not allowed in local struct}}
+    };
+  }
+}
+
+// Issue handling captures within expansion statements
+constexpr auto lambda_capture_in_expansion1(int i) -> int {
+    template for (constexpr int I : {0, 1, 2}) {
+        [&]{ i += I; }();
+        [&](int v){ i += I * v; }(I);
+        [&](auto v){ i += I * v; }(I);
+    }
+    return i;
+}
+
+constexpr auto lambda_capture_in_expansion2(auto i) -> int {
+    template for (constexpr int I : {0, 1, 2}) {
+        [&]{ i += I; }();
+        [&](int v){ i += I * v; }(I);
+        [&](auto v){ i += I * v; }(I);
+    }
+    return i;
+}
+
+static_assert(lambda_capture_in_expansion1(1) == 14);
+static_assert(lambda_capture_in_expansion2(1) == 14);


### PR DESCRIPTION
These were some issues I ran into with expansion statement/lambda interaction while trying to implement something else in Clang. Admittedly, all of this (except for the test cases) is Claude, because I don't actually know anything about how any of this works. But at least it does all work now? 

Signed-off-by: Barry Revzin \<barry.revzin@gmail.com\> 