### PR TITLE
Fix access to anon union member in splice expr

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -15689,6 +15689,31 @@ public:
 
   const CXXMetafunctionExpr::ImplFn &getMetafunctionCb(unsigned FnID);
 
+  static IndirectFieldDecl *findInjectedIndirectField(CXXRecordDecl *Outer,
+                                                      FieldDecl *FD) {
+    if (!Outer || !FD)
+      return nullptr;
+
+    DeclarationName N = FD->getDeclName();
+    if (!N)
+      return nullptr;
+
+    DeclContext::lookup_result R = Outer->lookup(N);
+    for (NamedDecl *ND : R) {
+      auto *IFD = dyn_cast<IndirectFieldDecl>(ND);
+      if (!IFD)
+        continue;
+
+      // The injected decl’s chain ends with the actual field inside the anonymous
+      // record.
+      auto Chain = IFD->chain();
+      if (!Chain.empty() && Chain.back() == FD)
+        return IFD;
+    }
+
+    return nullptr;
+  }
+
 private:
   // Lambdas having bound references to this Sema object, used to evaluate
   // metafunction (C++26, P2996) at constant evaluation time.

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -14614,16 +14614,8 @@ QualType Sema::CheckAddressOfOperand(ExprResult &OrigOp, SourceLocation OpLoc) {
             return QualType();
           }
 
-          while (cast<RecordDecl>(Ctx)->isAnonymousStructOrUnion()) {
+          while (cast<RecordDecl>(Ctx)->isAnonymousStructOrUnion())
             Ctx = Ctx->getParent();
-            if (!isa<RecordDecl>(Ctx)) {
-              Diag(OpLoc,
-                   diag::err_cannot_form_pointer_to_member_anon_union)
-                << dcl->getDeclName()
-                << cast<RecordDecl>(dcl->getDeclContext());
-              return QualType();
-            }
-          }
 
           QualType MPTy = Context.getMemberPointerType(
               unwrapped->getType(), DRE->getQualifier(),

--- a/clang/lib/Sema/SemaExprMember.cpp
+++ b/clang/lib/Sema/SemaExprMember.cpp
@@ -884,6 +884,31 @@ static bool isPointerToRecordType(QualType T) {
   return false;
 }
 
+static IndirectFieldDecl *findInjectedIndirectField(CXXRecordDecl *Outer,
+                                                    FieldDecl *FD) {
+  if (!Outer || !FD)
+    return nullptr;
+
+  DeclarationName N = FD->getDeclName();
+  if (!N)
+    return nullptr;
+
+  DeclContext::lookup_result R = Outer->lookup(N);
+  for (NamedDecl *ND : R) {
+    auto *IFD = dyn_cast<IndirectFieldDecl>(ND);
+    if (!IFD)
+      continue;
+
+    // The injected decl’s chain ends with the actual field inside the anonymous
+    // record.
+    auto Chain = IFD->chain();
+    if (!Chain.empty() && Chain.back() == FD)
+      return IFD;
+  }
+
+  return nullptr;
+}
+
 ExprResult
 Sema::BuildMemberReferenceExpr(Expr *BaseExpr, QualType BaseExprType,
                                SourceLocation OpLoc, bool IsArrow,
@@ -1009,6 +1034,22 @@ Sema::BuildMemberReferenceExpr(Expr *BaseExpr, QualType BaseExprType,
   DeclAccessPair FoundDecl = R.begin().getPair();
   NamedDecl *MemberDecl = R.getFoundDecl();
 
+  // Normalize a FieldDecl to the injected IndirectFieldDecl in the parent
+  // record when the base object is that parent record.
+  if (auto *FD = dyn_cast<FieldDecl>(MemberDecl)) {
+    auto *InnerRD = dyn_cast<RecordDecl>(FD->getDeclContext());
+    if (InnerRD && InnerRD->isAnonymousStructOrUnion()) {
+      auto *OuterRD = dyn_cast<CXXRecordDecl>(InnerRD->getDeclContext());
+      auto *BaseRD = BaseType->getAsCXXRecordDecl();
+      if (OuterRD && BaseRD &&
+          OuterRD->getCanonicalDecl() == BaseRD->getCanonicalDecl()) {
+        if (IndirectFieldDecl *IFD = findInjectedIndirectField(OuterRD, FD)) {
+          MemberDecl = IFD;
+          FoundDecl = DeclAccessPair::make(IFD, IFD->getAccess());
+        }
+      }
+    }
+  }
   // FIXME: diagnose the presence of template arguments now.
 
   // If the decl being referenced had an error, return an error for this
@@ -1234,6 +1275,21 @@ Sema::BuildMemberReferenceExpr(Scope *S, Expr *Base, SourceLocation OpLoc,
 
   DeclarationNameInfo NameInfo(cast<NamedDecl>(ND)->getDeclName(),
                                ND->getLocation());
+  if (auto *FD = dyn_cast<FieldDecl>(ND)) {
+    auto *InnerRD = dyn_cast<RecordDecl>(FD->getDeclContext());
+    if (InnerRD && InnerRD->isAnonymousStructOrUnion()) {
+      if (auto *OuterRD = dyn_cast<CXXRecordDecl>(InnerRD->getDeclContext())) {
+        if (IndirectFieldDecl *IFD = findInjectedIndirectField(OuterRD, FD)) {
+          ND = IFD;
+          NameInfo = DeclarationNameInfo(IFD->getDeclName(), IFD->getLocation());
+        }
+      }
+    }
+  }
+  LookupResult LR(*this, NameInfo, LookupMemberName);
+  if (LR.empty())
+    LR.addDecl(ND);
+  LR.resolveKind();
   {
     CXXRecordDecl *DerivedRecord = [](QualType QT) {
       if (QualType PT = QT->getPointeeType(); !PT.isNull())
@@ -1257,10 +1313,6 @@ Sema::BuildMemberReferenceExpr(Scope *S, Expr *Base, SourceLocation OpLoc,
     }
   }
 
-  LookupResult LR(*this, NameInfo, LookupMemberName);
-  if (LR.empty())
-    LR.addDecl(ND);
-  LR.resolveKind();
 
   // Obnoxious translating of TemplateArgumentList to TemplateArgumentListInfo..
   if (auto *FD = dyn_cast<FunctionDecl>(ND);

--- a/clang/lib/Sema/SemaExprMember.cpp
+++ b/clang/lib/Sema/SemaExprMember.cpp
@@ -884,31 +884,6 @@ static bool isPointerToRecordType(QualType T) {
   return false;
 }
 
-static IndirectFieldDecl *findInjectedIndirectField(CXXRecordDecl *Outer,
-                                                    FieldDecl *FD) {
-  if (!Outer || !FD)
-    return nullptr;
-
-  DeclarationName N = FD->getDeclName();
-  if (!N)
-    return nullptr;
-
-  DeclContext::lookup_result R = Outer->lookup(N);
-  for (NamedDecl *ND : R) {
-    auto *IFD = dyn_cast<IndirectFieldDecl>(ND);
-    if (!IFD)
-      continue;
-
-    // The injected decl’s chain ends with the actual field inside the anonymous
-    // record.
-    auto Chain = IFD->chain();
-    if (!Chain.empty() && Chain.back() == FD)
-      return IFD;
-  }
-
-  return nullptr;
-}
-
 ExprResult
 Sema::BuildMemberReferenceExpr(Expr *BaseExpr, QualType BaseExprType,
                                SourceLocation OpLoc, bool IsArrow,
@@ -1034,22 +1009,6 @@ Sema::BuildMemberReferenceExpr(Expr *BaseExpr, QualType BaseExprType,
   DeclAccessPair FoundDecl = R.begin().getPair();
   NamedDecl *MemberDecl = R.getFoundDecl();
 
-  // Normalize a FieldDecl to the injected IndirectFieldDecl in the parent
-  // record when the base object is that parent record.
-  if (auto *FD = dyn_cast<FieldDecl>(MemberDecl)) {
-    auto *InnerRD = dyn_cast<RecordDecl>(FD->getDeclContext());
-    if (InnerRD && InnerRD->isAnonymousStructOrUnion()) {
-      auto *OuterRD = dyn_cast<CXXRecordDecl>(InnerRD->getDeclContext());
-      auto *BaseRD = BaseType->getAsCXXRecordDecl();
-      if (OuterRD && BaseRD &&
-          OuterRD->getCanonicalDecl() == BaseRD->getCanonicalDecl()) {
-        if (IndirectFieldDecl *IFD = findInjectedIndirectField(OuterRD, FD)) {
-          MemberDecl = IFD;
-          FoundDecl = DeclAccessPair::make(IFD, IFD->getAccess());
-        }
-      }
-    }
-  }
   // FIXME: diagnose the presence of template arguments now.
 
   // If the decl being referenced had an error, return an error for this
@@ -1254,8 +1213,8 @@ Sema::BuildMemberReferenceExpr(Scope *S, Expr *Base, SourceLocation OpLoc,
   TemplateArgumentListInfo TemplateArgs(RHS->getBeginLoc(), RHS->getEndLoc());
   if (auto *DRE = dyn_cast<DeclRefExpr>(RHS->getModel())) {
     ValueDecl *D = DRE->getDecl();
-    if (isa<FieldDecl>(D) || isa<CXXMethodDecl>(D) ||
-        (isa<VarDecl>(D) && DRE->getQualifierLoc())) {
+    if (isa<FieldDecl>(D) || isa<IndirectFieldDecl>(D) || isa<CXXMethodDecl>(D)
+     || (isa<VarDecl>(D) && DRE->getQualifierLoc())) {
       ND = D;
       // NOTE(P2996): Uncomment the following line for static dispatch.
       // SS.Adopt(DRE->getQualifierLoc());
@@ -1275,21 +1234,6 @@ Sema::BuildMemberReferenceExpr(Scope *S, Expr *Base, SourceLocation OpLoc,
 
   DeclarationNameInfo NameInfo(cast<NamedDecl>(ND)->getDeclName(),
                                ND->getLocation());
-  if (auto *FD = dyn_cast<FieldDecl>(ND)) {
-    auto *InnerRD = dyn_cast<RecordDecl>(FD->getDeclContext());
-    if (InnerRD && InnerRD->isAnonymousStructOrUnion()) {
-      if (auto *OuterRD = dyn_cast<CXXRecordDecl>(InnerRD->getDeclContext())) {
-        if (IndirectFieldDecl *IFD = findInjectedIndirectField(OuterRD, FD)) {
-          ND = IFD;
-          NameInfo = DeclarationNameInfo(IFD->getDeclName(), IFD->getLocation());
-        }
-      }
-    }
-  }
-  LookupResult LR(*this, NameInfo, LookupMemberName);
-  if (LR.empty())
-    LR.addDecl(ND);
-  LR.resolveKind();
   {
     CXXRecordDecl *DerivedRecord = [](QualType QT) {
       if (QualType PT = QT->getPointeeType(); !PT.isNull())
@@ -1313,6 +1257,10 @@ Sema::BuildMemberReferenceExpr(Scope *S, Expr *Base, SourceLocation OpLoc,
     }
   }
 
+  LookupResult LR(*this, NameInfo, LookupMemberName);
+  if (LR.empty())
+    LR.addDecl(ND);
+  LR.resolveKind();
 
   // Obnoxious translating of TemplateArgumentList to TemplateArgumentListInfo..
   if (auto *FD = dyn_cast<FunctionDecl>(ND);

--- a/clang/lib/Sema/SemaReflect.cpp
+++ b/clang/lib/Sema/SemaReflect.cpp
@@ -1536,6 +1536,32 @@ QualType Sema::BuildReflectionSpliceTypeLoc(TypeLocBuilder &TLB,
   return SpliceTy;
 }
 
+static ValueDecl *normalizeSplicedMemberDecl(ValueDecl *VD) {
+  auto *FD = dyn_cast_or_null<FieldDecl>(VD);
+  if (!FD)
+    return VD;
+
+  auto *InnerRD = dyn_cast<RecordDecl>(FD->getDeclContext());
+  if (!InnerRD || !InnerRD->isAnonymousStructOrUnion())
+    return VD;
+
+  // Walk up through anonymous records; the injected decl we want lives in the
+  // first non-anonymous containing record.
+  DeclContext *DC = InnerRD->getDeclContext();
+  auto *OuterRD = dyn_cast<CXXRecordDecl>(DC);
+  while (OuterRD && OuterRD->isAnonymousStructOrUnion()) {
+    DC = OuterRD->getDeclContext();
+    OuterRD = dyn_cast<CXXRecordDecl>(DC);
+  }
+  if (!OuterRD)
+    return VD;
+
+  if (IndirectFieldDecl *IFD = Sema::findInjectedIndirectField(OuterRD, FD))
+    return IFD;
+
+  return VD;
+}
+
 ExprResult Sema::BuildReflectionSpliceExpr(SourceLocation TemplateKWLoc,
                                            SpliceSpecifier *Splice,
                                            bool AllowMemberReference) {
@@ -1593,12 +1619,12 @@ ExprResult Sema::BuildReflectionSpliceExpr(SourceLocation TemplateKWLoc,
       if (auto *VD = dyn_cast<VarDecl>(TheDecl);
           VD && CheckSpliceVar(*this, VD, Splice->getSourceRange()))
         return ExprError();
+      auto * VD = normalizeSplicedMemberDecl(cast<ValueDecl>(TheDecl));
 
       // Create a new DeclRefExpr, since the operand of the reflect expression
       // was parsed in an unevaluated context (but a splice expression is not
       // necessarily, and frequently not, in such a context).
-      Result = CreateRefToDecl(*this, cast<ValueDecl>(TheDecl),
-                               Splice->getBeginLoc());
+      Result = CreateRefToDecl(*this, VD, Splice->getBeginLoc());
       MarkDeclRefReferenced(cast<DeclRefExpr>(Result), nullptr);
       Result = CXXSpliceExpr::Create(Context, Result->getValueKind(),
                                      TemplateKWLoc, Splice, Result,

--- a/libcxx/test/std/experimental/reflection/anon-union.cpp
+++ b/libcxx/test/std/experimental/reflection/anon-union.cpp
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright 2025 Bloomberg Finance L.P.
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03 || c++11 || c++14 || c++17 || c++20
+// ADDITIONAL_COMPILE_FLAGS: -freflection
+
+// <experimental/reflection>
+//
+// [reflection]
+
+struct foo {
+  int i;
+  union {
+    int a;
+    long b;
+  };
+};
+
+constexpr foo bar { .i = 11, .a = 1 };
+static_assert(bar.[:^^foo::a:] == 1);
+static_assert(bar.*&[:^^foo::a:] == 1);

--- a/libcxx/test/std/experimental/reflection/anon-union.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/anon-union.pass.cpp
@@ -26,3 +26,7 @@ struct foo {
 constexpr foo bar { .i = 11, .a = 1 };
 static_assert(bar.[:^^foo::a:] == 1);
 static_assert(bar.*&[:^^foo::a:] == 1);
+
+int main() {
+  return 0;
+}


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #<number>*
#251 

**Describe your changes**
Fix indirect field access when they occur in splice expression by normalizing the indirection via getModel()

**Testing performed**
Added UT 
Note
```
build/bin/llvm-lit -v ./build/runtimes/runtimes-bins/libcxx/test/std/experimental/reflection
Failed Tests (4):
  llvm-libc++-shared.cfg.in :: std/experimental/reflection/module-imports.sh.cpp
  llvm-libc++-shared.cfg.in :: std/experimental/reflection/p2996-ex-parsing-command-line-options-1.sh.cpp
  llvm-libc++-shared.cfg.in :: std/experimental/reflection/p2996-ex-parsing-command-line-options-2.sh.cpp
  llvm-libc++-shared.cfg.in :: std/experimental/reflection/p3096-fn-parameters.pass.cpp
```
Two of those were broken long ago, but the two `parsing-command` line were broken recently, yet not in this PR
We ll need to open an issue... (nvm PR 258 is fixing this)

**Additional context**
nop