### PR TITLE
Defer expansion statement body instantiation

### DIFF
--- a/clang/include/clang/AST/DeclTemplate.h
+++ b/clang/include/clang/AST/DeclTemplate.h
@@ -3347,11 +3347,11 @@ public:
 ///
 /// TODO(P2996): This could probably be a 'TemplateDecl'.
 class ExpansionStmtDecl : public Decl, public DeclContext {
-  CXXExpansionStmt *Expansion;
+  Stmt *Expansion;
   TemplateParameterList *TParams;
 
   ExpansionStmtDecl(DeclContext *DC, SourceLocation Loc,
-                    CXXExpansionStmt *Expansion,
+                    Stmt *Expansion,
                     TemplateParameterList *TParams);
 
   virtual void anchor();
@@ -3361,12 +3361,12 @@ public:
 
   static ExpansionStmtDecl *Create(ASTContext &C, DeclContext *DC,
                                    SourceLocation Loc,
-                                   CXXExpansionStmt *Expansion,
+                                   Stmt *Expansion,
                                    TemplateParameterList *TParams);
   static ExpansionStmtDecl *CreateDeserialized(ASTContext &C, GlobalDeclID ID);
 
-  CXXExpansionStmt *getStmt() const { return Expansion; }
-  void setStmt(CXXExpansionStmt *S) { Expansion = S; }
+  Stmt *getStmt() const { return Expansion; }
+  void setStmt(Stmt *S) { Expansion = S; }
 
   NonTypeTemplateParmDecl *getTemplateParm() const {
     return cast<NonTypeTemplateParmDecl>(TParams->getParam(0));

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -15777,6 +15777,8 @@ public:
                                        MultiExprArg SubExprs,
                                        SourceLocation RBraceLoc);
 
+  StmtResult FinishCXXExpansionStmt(Stmt *S, UnsignedOrNone Size);
+
   StmtResult FinishCXXExpansionStmt(Stmt *Heading, Stmt *Body);
 
   StmtResult BuildCXXExpansionStmt(

--- a/clang/lib/AST/DeclTemplate.cpp
+++ b/clang/lib/AST/DeclTemplate.cpp
@@ -1639,7 +1639,7 @@ void TemplateParamObjectDecl::printAsInit(llvm::raw_ostream &OS,
 }
 
 ExpansionStmtDecl::ExpansionStmtDecl(DeclContext *DC, SourceLocation Loc,
-                                     CXXExpansionStmt *Expansion,
+                                     Stmt *Expansion,
                                      TemplateParameterList *TParams)
     : Decl(ExpansionStmt, DC, Loc),
       DeclContext(ExpansionStmt), Expansion(Expansion), TParams(TParams) { }
@@ -1648,7 +1648,7 @@ void ExpansionStmtDecl::anchor() {}
 
 ExpansionStmtDecl *ExpansionStmtDecl::Create(ASTContext &C, DeclContext *DC,
                                              SourceLocation Loc,
-                                             CXXExpansionStmt *Expansion,
+                                             Stmt *Expansion,
                                              TemplateParameterList *TParams) {
   return new (C, DC) ExpansionStmtDecl(DC, Loc, Expansion, TParams);
 }

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -257,7 +257,6 @@ Retry:
                                                     Tok.getLocation()));
       assert(ExpansionDecl && "no ExpansionStmtDecl returned");
 
-      CXXExpansionStmt *Expansion;
       {
         Sema::ContextRAII CtxGuard(Actions, ExpansionDecl, /*NewThis=*/false);
         TemplateParameterDepthRAII TParamDepthGuard(TemplateParameterDepth);
@@ -266,16 +265,16 @@ Retry:
         StmtResult SR = ParseForStatement(TrailingElseLoc);
         if (SR.isInvalid())
           return SR;
-        Expansion = cast<CXXExpansionStmt>(SR.get());
-        ExpansionDecl->setStmt(Expansion);
+        ExpansionDecl->setStmt(SR.get());
       }
 
       DeclSpec DS(AttrFactory);
       DeclGroupPtrTy DeclGroupPtr =
           Actions.FinalizeDeclaratorGroup(getCurScope(), DS, {ExpansionDecl});
 
-      return Actions.ActOnDeclStmt(DeclGroupPtr, Expansion->getBeginLoc(),
-                                   Expansion->getEndLoc());
+      return Actions.ActOnDeclStmt(DeclGroupPtr,
+                                   ExpansionDecl->getStmt()->getBeginLoc(),
+                                   ExpansionDecl->getStmt()->getEndLoc());
     }
 
     SourceLocation DeclEnd;

--- a/clang/lib/Sema/SemaExpand.cpp
+++ b/clang/lib/Sema/SemaExpand.cpp
@@ -15,10 +15,12 @@
 #include "clang/AST/Decl.h"
 #include "clang/AST/DynamicRecursiveASTVisitor.h"
 #include "clang/Basic/DiagnosticSema.h"
+#include "clang/Basic/UnsignedOrNone.h"
 #include "clang/Lex/Preprocessor.h"
 #include "clang/Sema/EnterExpressionEvaluationContext.h"
 #include "clang/Sema/Initialization.h"
 #include "clang/Sema/Lookup.h"
+#include "clang/Sema/Ownership.h"
 #include "clang/Sema/Overload.h"
 #include "clang/Sema/Sema.h"
 #include "clang/Sema/Template.h"
@@ -516,8 +518,9 @@ Sema::BuildCXXExpansionInitListSelectExpr(CXXExpansionInitListExpr *Range,
   return SubExprs[I];
 }
 
-StmtResult Sema::FinishCXXExpansionStmt(Stmt *Heading, Stmt *Body) {
-  if (!Heading || !Body)
+// When Size is none means the size is dependent.
+StmtResult Sema::FinishCXXExpansionStmt(Stmt *S, UnsignedOrNone Size) {
+  if (!S)
     return StmtError();
 
   // Diagnose identifier labels.
@@ -529,49 +532,44 @@ StmtResult Sema::FinishCXXExpansionStmt(Stmt *Heading, Stmt *Body) {
       return false;
     }
   } Visitor(*this);
-  if (!Visitor.TraverseStmt(Body))
+  if (!Visitor.TraverseStmt(S))
     return StmtError();
 
-  CXXExpansionStmt *Expansion = cast<CXXExpansionStmt>(Heading);
-  Expansion->setBody(Body);
+  if (!Size)
+    return S;
 
-  if (Expansion->hasDependentSize())
-    return Expansion;
+  if (*Size == 0u)
+    return S;
 
-  // Return an empty statement if the range is empty.
-  if (Expansion->getNumInstantiations() == 0)
-     return Expansion;
+  CXXExpansionStmt *Expansion = cast<CXXExpansionStmt>(S);
 
   // Create a compound statement binding loop and body.
-  Stmt *VarAndBody[] = {Expansion->getExpansionVarStmt(), Body};
+  Stmt *VarAndBody[] = {Expansion->getExpansionVarStmt(), Expansion->getBody()};
   Stmt *CombinedBody = CompoundStmt::Create(Context, VarAndBody,
                                             FPOptionsOverride(),
                                             Expansion->getBeginLoc(),
                                             Expansion->getEndLoc());
 
-  ExpansionStmtDecl *StmtDecl = cast<ExpansionStmtDecl>(CurContext);
-  DeclContext *DC = CurContext;
-  while (isa<ExpansionStmtDecl>(DC))
-    DC = DC->getParent();
-
   // Expand the body for each instantiation.
   SmallVector<Stmt *, 4> Instantiations;
-  while (Instantiations.size() < Expansion->getNumInstantiations()) {
+  while (Instantiations.size() < *Size) {
 
-    ContextRAII CtxGuard(*this, DC, /*NewThis=*/false);
-    ExpansionStmtSynthesisRAII ExpansionGuard(*this, !DC->isDependentContext());
+    ContextRAII CtxGuard(*this, CurContext, /*NewThis=*/false);
+    ExpansionStmtSynthesisRAII ExpansionGuard(*this,
+                                             !CurContext->isDependentContext());
 
     TemplateArgument TArgs[] = {
         { Context, llvm::APSInt::get(Instantiations.size()),
           Context.getSizeType() }
     };
-    MultiLevelTemplateArgumentList MTArgList(StmtDecl, TArgs, true);
+    MultiLevelTemplateArgumentList MTArgList(
+        cast<ExpansionStmtDecl>(CurContext), TArgs, true);
     MTArgList.addOuterRetainedLevels(
             ExtractParmVarDeclDepth(Expansion->getTParamRef()));
 
     LocalInstantiationScope LIScope(*this, /*CombineWithOuterScope=*/true);
-    InstantiatingTemplate Inst(*this, Body->getBeginLoc(), Expansion, TArgs,
-                               Body->getSourceRange());
+    InstantiatingTemplate Inst(*this, S->getBeginLoc(), Expansion, TArgs,
+                               S->getSourceRange());
 
     StmtResult Instantiation = SubstStmt(CombinedBody, MTArgList);
 
@@ -580,14 +578,22 @@ StmtResult Sema::FinishCXXExpansionStmt(Stmt *Heading, Stmt *Body) {
     Instantiations.push_back(Instantiation.get());
   }
 
-  // Allocate a more permanent buffer to hold pointers to Stmts.
-  Stmt **StmtStorage = new (Context) Stmt *[Instantiations.size()];
-  std::memcpy(StmtStorage, Instantiations.data(),
-              Instantiations.size() * sizeof(Stmt *));
+  return CompoundStmt::Create(Context, Instantiations, FPOptionsOverride(),
+                              Expansion->getBeginLoc(), Expansion->getEndLoc());
+}
 
-  // Attach Stmt buffer to the CXXExpansionStmt, and return.
-  Expansion->setInstantiations(StmtStorage);
-  return Expansion;
+StmtResult Sema::FinishCXXExpansionStmt(Stmt *Heading, Stmt *Body) {
+  if (!Heading || !Body)
+    return StmtError();
+
+  CXXExpansionStmt *Expansion = cast<CXXExpansionStmt>(Heading);
+  Expansion->setBody(Body);
+
+  UnsignedOrNone Size = std::nullopt;
+  if (!Expansion->hasDependentSize()) {
+    Size = Expansion->getNumInstantiations();
+  }
+  return FinishCXXExpansionStmt(Heading, Size);
 }
 
 ExprResult Sema::ActOnCXXExpansionInitList(SourceLocation LBraceLoc,

--- a/clang/lib/Sema/SemaReflect.cpp
+++ b/clang/lib/Sema/SemaReflect.cpp
@@ -1697,7 +1697,6 @@ ExprResult Sema::BuildReflectionSpliceExpr(SourceLocation TemplateKWLoc,
     case ReflectionKind::Declaration: {
       Decl *TheDecl = Refl.getReflectedDecl();
 
-      // Class members may not be implicitly referenced through a splice.
       if (!AllowMemberReference &&
           (isa<FieldDecl>(TheDecl) ||
            (isa<CXXMethodDecl>(TheDecl) &&

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -2081,7 +2081,7 @@ Decl *TemplateDeclInstantiator::VisitExpansionStmtDecl(ExpansionStmtDecl *D) {
       cast<ExpansionStmtDecl>(
           SemaRef.BuildExpansionStmtDeclaration(
               D->getBeginLoc(), cast<NonTypeTemplateParmDecl>(NTTP)));
-  CXXExpansionStmt *OldStmt = D->getStmt();
+  Stmt *OldStmt = D->getStmt();
   assert(Result && OldStmt);
 
   // Enter the scope of this instantiation. We don't use
@@ -2092,7 +2092,7 @@ Decl *TemplateDeclInstantiator::VisitExpansionStmtDecl(ExpansionStmtDecl *D) {
   StmtResult SR = SemaRef.SubstStmt(OldStmt, TemplateArgs);
   if (SR.isInvalid())
     return nullptr;
-  Result->setStmt(cast<CXXExpansionStmt>(SR.get()));
+  Result->setStmt(SR.get());
 
   return Result;
 }

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -33,6 +33,7 @@
 #include "clang/AST/StmtOpenACC.h"
 #include "clang/AST/StmtOpenMP.h"
 #include "clang/AST/StmtSYCL.h"
+#include "clang/Basic/UnsignedOrNone.h"
 #include "clang/Basic/DiagnosticParse.h"
 #include "clang/Basic/OpenMPKinds.h"
 #include "clang/Sema/Designator.h"
@@ -9090,9 +9091,9 @@ TreeTransform<Derived>::TransformCXXReflectExpr(CXXReflectExpr *E) {
                                           E->getOperandRange().getBegin(),
                                           Transformed));
   }
+  case ReflectionKind::Attribute:
   case ReflectionKind::Object:
   case ReflectionKind::Value:
-  case ReflectionKind::Attribute:
     return E;
   case ReflectionKind::Null:
   case ReflectionKind::BaseSpecifier:
@@ -9208,23 +9209,16 @@ TreeTransform<Derived>::TransformExplDependentCallExpr(
   return getSema().BuildExplDependentCallExpr(Call.get(), NewDepth);
 }
 
+// Transform only rewrites the size expression and passes the result to
+// Sema::FinishCXXExpansionStmt. Instantiation is deferred until the expansion
+// statement is expanded.
 // Expansions Statements (C++2c, P1306).
 
 template <typename Derived>
 StmtResult
 TreeTransform<Derived>::TransformCXXIndeterminateExpansionStmt(
                                              CXXIndeterminateExpansionStmt *S) {
-  // Transform optional init-statement.
-  Stmt *Init = S->getInit();
-  if (Init) {
-    StmtResult SR = getDerived().TransformStmt(Init,
-                                               StmtDiscardKind::NotDiscarded);
-    if (SR.isInvalid())
-      return StmtError();
-    Init = SR.get();
-  }
-
-  // Transform expansion variable declaration (e.g., could have dependent type).
+  // Transform expansion variable declaration
   StmtResult SR = getDerived().TransformStmt(S->getExpansionVarStmt(),
                                              StmtDiscardKind::NotDiscarded);
   if (SR.isInvalid())
@@ -9237,218 +9231,109 @@ TreeTransform<Derived>::TransformCXXIndeterminateExpansionStmt(
     return StmtError();
   Expr *TParamRef = ER.get();
 
-  // Build a new expansion statement.
+  // Build a new expansion statement - this resolves Indeterminate to
+  // Iterable or Destructurable and computes the size
   SR = SemaRef.BuildCXXExpansionStmt(S->getTemplateKWLoc(), S->getForLoc(),
-                                     S->getLParenLoc(), Init, ExpansionVarStmt,
+                                     S->getLParenLoc(), S->getInit(),
+                                     ExpansionVarStmt,
                                      S->getColonLoc(), S->getRParenLoc(),
                                      TParamRef);
   if (SR.isInvalid())
     return StmtError();
-  Stmt *Rebuilt = SR.get();
 
-  // Transform the body.
-  SR = getDerived().TransformStmt(S->getBody());
-  if (SR.isInvalid())
-    return StmtError();
-  Stmt *Body = SR.get();
+  CXXExpansionStmt *Rebuilt = cast<CXXExpansionStmt>(SR.get());
 
-  // Finish expanding the statement.
-  SR = SemaRef.FinishCXXExpansionStmt(Rebuilt, Body);
-  if (SR.isInvalid())
-    return StmtError();
-
-  return SR.get();
+  // Now we can get the size from the rebuilt (concrete) statement
+  UnsignedOrNone Size = std::nullopt;
+  if (!Rebuilt->hasDependentSize()) {
+    Size = Rebuilt->getNumInstantiations();
+  }
+  return SemaRef.FinishCXXExpansionStmt(S, Size);
 }
 
 template <typename Derived>
 StmtResult
 TreeTransform<Derived>::TransformCXXIterableExpansionStmt(
                                                   CXXIterableExpansionStmt *S) {
-  // Transform optional init-statement.
-  Stmt *Init = S->getInit();
-  if (Init) {
-    StmtResult SR = getDerived().TransformStmt(Init,
-                                               StmtDiscardKind::NotDiscarded);
-    if (SR.isInvalid())
-      return StmtError();
-    Init = SR.get();
-  }
-
-  StmtResult SR;
+  // Transform the range expression (size depends on the range).
   {
-    auto Ctx = Sema::ExpressionEvaluationContext::PotentiallyEvaluated;
-    if (S->getExpansionVariable()->isConstexpr())
-      Ctx = Sema::ExpressionEvaluationContext::ImmediateFunctionContext;
-    EnterExpressionEvaluationContext ExprEvalCtx(getSema(), Ctx);
+    const Expr *Init = S->getExpansionVariable()->getInit();
+    while (const auto *WithCleanups = dyn_cast<ExprWithCleanups>(Init))
+      Init = WithCleanups->getSubExpr();
 
-    // Transform the range variable.
-    // This must be done only once per expansion-statement, so we do it here
-    // rather than in the select-expression.
-    {
-      const Expr *Init = S->getExpansionVariable()->getInit();
-      while (const auto *WithCleanups = dyn_cast<ExprWithCleanups>(Init))
-        Init = WithCleanups->getSubExpr();
+    auto *Select = cast<CXXIterableExpansionSelectExpr>(Init);
+    auto *New = getDerived().TransformDefinition(Select->getBeginLoc(),
+                                                 Select->getRangeVar());
+    if (!New || New->isInvalidDecl())
+      return StmtError();
+  } // No need to keep the new RangeVar; it is already in the current context.
 
-      if (auto *Select = cast<CXXIterableExpansionSelectExpr>(Init)) {
-        auto *New = getDerived().TransformDefinition(Select->getBeginLoc(),
-                                                     Select->getRangeVar());
-        if (!New || New->isInvalidDecl())
-          return StmtError();
+  // Transform size expression (end - begin).
+  ExprResult SizeResult = getDerived().TransformExpr(S->getSizeExpr());
+  if (SizeResult.isInvalid())
+    return StmtError();
+
+  UnsignedOrNone Size = std::nullopt;
+
+  if (Expr *SizeExpr = SizeResult.get()) {
+    if (!SizeExpr->isValueDependent()) {
+      Expr::EvalResult Result;
+      if (SizeExpr->EvaluateAsInt(Result, SemaRef.Context)) {
+        Size = static_cast<unsigned>(Result.Val.getInt().getZExtValue());
       }
     }
-
-    SR = getDerived().TransformStmt(S->getExpansionVarStmt(),
-                                    StmtDiscardKind::NotDiscarded);
-    if (SR.isInvalid())
-      return StmtError();
-    DeclStmt *ExpansionVarStmt = cast<DeclStmt>(SR.get());
-
-    ExprResult TParamRef =
-        getDerived().TransformExpr(cast<Expr>(S->getTParamRef()));
-    ExprResult Size = getDerived().TransformExpr(cast<Expr>(S->getSizeExpr()));
-    if (TParamRef.isInvalid() || Size.isInvalid())
-      return StmtError();
-
-    SR = SemaRef.BuildCXXIterableExpansionStmt(S->getTemplateKWLoc(),
-                                               S->getForLoc(),
-                                               S->getLParenLoc(),
-                                               Init, ExpansionVarStmt,
-                                               S->getColonLoc(),
-                                               S->getRParenLoc(),
-                                               TParamRef.get(),
-                                               Size.get());
   }
-  if (SR.isInvalid())
-    return StmtError();
-  Stmt *Rebuilt = SR.get();
-
-  // Transform the body.
-  SR = getDerived().TransformStmt(S->getBody());
-  if (SR.isInvalid())
-    return StmtError();
-  Stmt *Body = SR.get();
 
   // Finish expanding the statement.
-  return SemaRef.FinishCXXExpansionStmt(Rebuilt, Body);
+  return SemaRef.FinishCXXExpansionStmt(S, Size);
 }
 
 template <typename Derived>
 StmtResult
 TreeTransform<Derived>::TransformCXXDestructurableExpansionStmt(
                                             CXXDestructurableExpansionStmt *S) {
-  // Transform optional init-statement.
-  Stmt *Init = S->getInit();
-  if (Init) {
-    StmtResult SR = getDerived().TransformStmt(Init,
-                                               StmtDiscardKind::NotDiscarded);
-    if (SR.isInvalid())
-      return StmtError();
-    Init = SR.get();
-  }
-
-  // Transform the structured bindings variable.
-  // This must be done only once per expansion-statement, so we do it here
-  // rather than in the select-expression.
+  // Transform the decomposition decl (size depends on it).
   {
     const Expr *Init = S->getExpansionVariable()->getInit();
     while (const auto *WithCleanups = dyn_cast<ExprWithCleanups>(Init))
       Init = WithCleanups->getSubExpr();
-
-    if (auto *Select = cast<CXXDestructurableExpansionSelectExpr>(Init)) {
-      auto *New = getDerived().TransformDefinition(
-          Select->getBeginLoc(), Select->getDecompositionDecl());
-      if (!New || New->isInvalidDecl())
-        return StmtError();
-    }
+    auto *Select = cast<CXXDestructurableExpansionSelectExpr>(Init);
+    auto *New = getDerived().TransformDefinition(
+        Select->getBeginLoc(), Select->getDecompositionDecl());
+    if (!New || New->isInvalidDecl())
+      return StmtError();
   }
 
-  // Transform expansion variable declaration (e.g., could have dependent type).
-  StmtResult SR = getDerived().TransformStmt(S->getExpansionVarStmt(),
-                                             StmtDiscardKind::NotDiscarded);
-  if (SR.isInvalid())
-    return StmtError();
-  DeclStmt *ExpansionVarStmt = cast<DeclStmt>(SR.get());
-
-  // Transform the expression referencing the template parameter.
-  SR = getDerived().TransformStmt(S->getTParamRef());
-  if (SR.isInvalid())
-    return StmtError();
-  DeclRefExpr *TParamRef = cast<DeclRefExpr>(SR.get());
-
-  // Build a new expansion statement.
-  SR = SemaRef.BuildCXXDestructurableExpansionStmt(S->getTemplateKWLoc(),
-                                                   S->getForLoc(),
-                                                   S->getLParenLoc(), Init,
-                                                   ExpansionVarStmt,
-                                                   S->getColonLoc(),
-                                                   S->getRParenLoc(),
-                                                   TParamRef);
-  if (SR.isInvalid())
-    return StmtError();
-  Stmt *Rebuilt = SR.get();
-
-  // Transform the body.
-  SR = getDerived().TransformStmt(S->getBody());
-  if (SR.isInvalid())
-    return StmtError();
-  Stmt *Body = SR.get();
-
-  // Finish expanding the statement.
-  SR = SemaRef.FinishCXXExpansionStmt(Rebuilt, Body);
-  if (SR.isInvalid())
+  // Transform size expression (tuple_size or binding count).
+  ExprResult SizeResult = getDerived().TransformExpr(S->getSizeExpr());
+  if (SizeResult.isInvalid())
     return StmtError();
 
-  return SR.get();
+  // Compute Size.
+  UnsignedOrNone Size = std::nullopt;
+  if (Expr *SizeExpr = SizeResult.get()) {
+    if (!SizeExpr->isValueDependent()) {
+      Expr::EvalResult Result;
+      if (SizeExpr->EvaluateAsInt(Result, SemaRef.Context)) {
+        Size = static_cast<unsigned>(Result.Val.getInt().getZExtValue());
+      }
+    }
+  }
+  return SemaRef.FinishCXXExpansionStmt(S, Size);
 }
 
 template <typename Derived>
 StmtResult
 TreeTransform<Derived>::TransformCXXInitListExpansionStmt(
                                                   CXXInitListExpansionStmt *S) {
-  // Transform optional init-statement.
-  Stmt *Init = S->getInit();
-  if (Init) {
-    StmtResult SR = getDerived().TransformStmt(Init);
-    if (SR.isInvalid())
-      return StmtError();
-    Init = SR.get();
+  // Size comes directly from CXXExpansionInitListExpr.
+  // No transform is needed because it does not depend on outer variables.
+  UnsignedOrNone Size = std::nullopt;
+
+  if (!S->hasDependentSize()) {
+    Size = S->getNumInstantiations();
   }
-
-  // Transform expansion variable declaration (e.g., could have dependent type).
-  StmtResult SR = getDerived().TransformStmt(S->getExpansionVarStmt());
-  if (SR.isInvalid())
-    return StmtError();
-  DeclStmt *ExpansionVarStmt = cast<DeclStmt>(SR.get());
-
-  // Transform the expression referencing the template parameter.
-  SR = getDerived().TransformStmt(S->getTParamRef(),
-                                  StmtDiscardKind::NotDiscarded);
-  if (SR.isInvalid())
-    return StmtError();
-  Expr *TParamRef = cast<Expr>(SR.get());
-
-  // Build a new expansion statement.
-  SR = SemaRef.BuildCXXInitListExpansionStmt(S->getTemplateKWLoc(),
-                                             S->getForLoc(), S->getLParenLoc(),
-                                             Init, ExpansionVarStmt,
-                                             S->getColonLoc(),
-                                             S->getRParenLoc(), TParamRef);
-  if (SR.isInvalid())
-    return StmtError();
-  Stmt *Rebuilt = SR.get();
-
-  // Transform the body.
-  SR = getDerived().TransformStmt(S->getBody());
-  if (SR.isInvalid())
-    return StmtError();
-  Stmt *Body = SR.get();
-
-  // Finish expanding the statement.
-  SR = SemaRef.FinishCXXExpansionStmt(Rebuilt, Body);
-  if (SR.isInvalid())
-    return StmtError();
-
-  return SR.get();
+  return SemaRef.FinishCXXExpansionStmt(S, Size);
 }
 
 template <typename Derived>

--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -2782,7 +2782,7 @@ void ASTDeclReader::VisitConstevalBlockDecl(ConstevalBlockDecl *D) {
 
 void ASTDeclReader::VisitExpansionStmtDecl(ExpansionStmtDecl *D) {
   VisitDecl(D);
-  D->Expansion = cast<CXXExpansionStmt>(Record.readStmt());
+  D->Expansion = Record.readStmt();
   D->TParams = Record.readTemplateParameterList();
 }
 

--- a/clang/test/SemaCXX/cxx2c-expansion-stmts.cpp
+++ b/clang/test/SemaCXX/cxx2c-expansion-stmts.cpp
@@ -422,3 +422,38 @@ auto parse_options() -> void {
     (void)lam;
   }
 }
+
+                           // ============================
+                           // non_constant_expansion_size
+                           // ============================
+
+namespace non_constant_expansion_size {
+
+struct range_t { int *b; int *e; };
+int *begin(range_t r);
+int *end(range_t r);
+
+template <typename T>
+void fn(T t) {
+  template for (auto e : t) // expected-error {{could not compute size of expansion}}
+    (void)e;
+}
+
+void run(range_t r) { fn(r); }
+
+}  // namespace non_constant_expansion_size
+
+                           // ====================
+                           // label_diagnostics
+                           // ====================
+
+namespace label_diagnostics {
+
+void fn() {
+  template for (auto e : {1, 2}) {
+    label:; // expected-error {{identifier labels are not allowed in expansion statements}}
+    (void)e;
+  }
+}
+
+}  // namespace label_diagnostics

--- a/libcxx/test/std/experimental/reflection/p3394-annotations.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/p3394-annotations.pass.cpp
@@ -11,6 +11,7 @@
 // UNSUPPORTED: c++03 || c++11 || c++14 || c++17 || c++20
 // ADDITIONAL_COMPILE_FLAGS: -freflection
 // ADDITIONAL_COMPILE_FLAGS: -fannotation-attributes
+// ADDITIONAL_COMPILE_FLAGS: -fexpansion-statements
 
 // <experimental/reflection>
 //
@@ -290,5 +291,39 @@ static_assert(func2_first == std::meta::reflect_constant(1));
 static_assert(func_first == std::meta::reflect_constant(test));
 }  // namespace bb_clang_p2996_issue_143_regression_test
 
+// =====================================
+// nested_template_for_over_annotations
+// =====================================
+
+namespace nested_template_for_over_annotations {
+
+enum class S { x, y };
+
+namespace T {
+[[= S::x]] consteval int p() { return 1; }
+[[= S::y]] consteval int p(int) { return 2; }
+} // namespace T
+
+template <std::meta::info Ns>
+consteval int run() {
+  int hits           = 0;
+  constexpr auto ctx = std::meta::access_context::unchecked();
+  template for (constexpr auto i : define_static_array(members_of(Ns, ctx))) {
+    if constexpr (std::meta::is_user_provided(i)) {
+      template for (constexpr auto a : define_static_array(annotations_of(i))) {
+        if constexpr (type_of(a) == ^^S) {
+          if constexpr (extract<S>(a) == S::x) {
+            hits += [:i:]();
+          }
+        }
+      }
+    }
+  }
+  return hits;
+}
+
+static_assert(run<^^T>() == 1);
+
+} // namespace nested_template_for_over_annotations
 
 int main() { }


### PR DESCRIPTION
Compute expansion size and instantiate after expansion to avoid premature body instantiation and spurious diagnostics. Reproducer: https://godbolt.org/z/dxqPxe6ed