### PR TITLE
reflect_enumerator

### DIFF
--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -5893,9 +5893,6 @@ bool reflect_enumerator(APValue &Result, ASTContext &C, MetaActions &Meta,
     return DiagnoseReflectionKind(Diagnoser, Range, "a variable of enumeration type",
                                   DescriptionOf(Scratch));
   }
-  // enum class C { RED };
-  // C c = C::RED;
-  // enumerator_of(^^c) == ^^C::RED;
   Decl *D = Scratch.getReflectedDecl();
   if (auto *VD = llvm::dyn_cast<VarDecl>(D)) {
     if (VD->hasInit()) {

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -783,6 +783,12 @@ static bool reflect_invoke(APValue &Result, ASTContext &C, MetaActions &Meta,
                            SourceRange Range, ArrayRef<Expr *> Args,
                            Decl *ContainingDecl);
 
+static bool reflect_enumerator(APValue &Result, ASTContext &C, MetaActions &Meta,
+                           EvalFn Evaluator, DiagFn Diagnoser,
+                           bool AllowInjection, QualType ResultTy,
+                           SourceRange Range, ArrayRef<Expr *> Args,
+                           Decl *ContainingDecl);
+
 // -----------------------------------------------------------------------------
 // Metafunction table
 //
@@ -893,10 +899,7 @@ static constexpr Metafunction Metafunctions[] = {
   { Metafunction::MFRK_bool, 1, 1, is_user_declared },
   { Metafunction::MFRK_metaInfo, 2, 2, reflect_result },
   { Metafunction::MFRK_metaInfo, 12, 12, data_member_spec },
-  { Metafunction::MFRK_metaInfo, 8, 8, enumerator_spec },
-  { Metafunction::MFRK_bool, 1, 1, is_enumerator_spec },
   { Metafunction::MFRK_metaInfo, 3, 3, define_aggregate },
-  { Metafunction::MFRK_metaInfo, 3, 3, define_enum },
   { Metafunction::MFRK_spliceFromArg, 2, 2, offset_of },
   { Metafunction::MFRK_sizeT, 1, 1, size_of },
   { Metafunction::MFRK_spliceFromArg, 2, 2, bit_offset_of },
@@ -926,10 +929,17 @@ static constexpr Metafunction Metafunctions[] = {
   { Metafunction::MFRK_metaInfo, 0, 0, current_access_context },
   { Metafunction::MFRK_bool, 3, 3, is_accessible },
 
+  // P4033
+  { Metafunction::MFRK_metaInfo, 8, 8, enumerator_spec },
+  { Metafunction::MFRK_bool, 1, 1, is_enumerator_spec },
+  { Metafunction::MFRK_metaInfo, 3, 3, define_enum },
+  { Metafunction::MFRK_metaInfo, 1, 1, reflect_enumerator },
+
   // Other bespoke functions (not proposed at this time)
   { Metafunction::MFRK_bool, 1, 1, is_access_specified },
   { Metafunction::MFRK_metaInfo, 5, 5, reflect_invoke },
 };
+
 constexpr const unsigned NumMetafunctions = sizeof(Metafunctions) /
                                             sizeof(Metafunction);
 
@@ -5868,6 +5878,37 @@ bool define_enum(APValue &Result, ASTContext &C, MetaActions &Meta,
       Meta.DefineEnum(foundDecl, EnumSpecs, ContainingDecl,
                                 TargetEnum, nullptr, Args[0]->getExprLoc());
   return SetAndSucceed(Result, makeReflection(completedEnum));
+}
+
+bool reflect_enumerator(APValue &Result, ASTContext &C, MetaActions &Meta,
+                   EvalFn Evaluator, DiagFn Diagnoser, bool AllowInjection,
+                   QualType ResultTy, SourceRange Range,
+                   ArrayRef<Expr *> Args, Decl *ContainingDecl) {
+  assert(Args[0]->getType()->isReflectionType());
+
+  APValue Scratch;
+  if (!Evaluator(Scratch, Args[0], true))
+    return true;
+  if (!Scratch.isReflectedDecl()) {
+    return DiagnoseReflectionKind(Diagnoser, Range, "a variable of enumeration type",
+                                  DescriptionOf(Scratch));
+  }
+  // enum class C { RED };
+  // C c = C::RED;
+  // enumerator_of(^^c) == ^^C::RED;
+  Decl *D = Scratch.getReflectedDecl();
+  if (auto *VD = llvm::dyn_cast<VarDecl>(D)) {
+    if (VD->hasInit()) {
+      Expr *Init = VD->getInit();
+      Init = Init->IgnoreImplicit(); // skip ghost ast wrapper stuff
+      if (auto *DRE = llvm::dyn_cast<DeclRefExpr>(Init)) {
+        if (auto *ECD = llvm::dyn_cast<EnumConstantDecl>(DRE->getDecl())) {
+          return SetAndSucceed(Result, makeReflection(ECD));
+        }
+      }
+    }
+  }
+  return true;
 }
 
 bool define_aggregate(APValue &Result, ASTContext &C, MetaActions &Meta,

--- a/libcxx/include/meta
+++ b/libcxx/include/meta
@@ -402,6 +402,7 @@ template <reflection_range R1 = initializer_list<info>,
   consteval auto reflect_invoke(info target,
                                 R1 &&tmpl_args, R2 &&args) -> info;
 
+consteval info reflect_enumerator(info r);
 
 } // namespace reflection_v2
 } // namespace meta
@@ -548,10 +549,7 @@ enum : unsigned {
   __metafn_is_user_declared,
   __metafn_reflect_result,
   __metafn_data_member_spec,
-  __metafn_enumerator_spec,
-  __metafn_is_enumerator_spec,
   __metafn_define_aggregate,
-  __metafn_define_enum,
   __metafn_offset_of,
   __metafn_size_of,
   __metafn_bit_offset_of,
@@ -580,6 +578,12 @@ enum : unsigned {
   // P3493 accessibility metafunctions
   __metafn_access_context,
   __metafn_is_accessible,
+
+  // P4033
+  __metafn_enumerator_spec,
+  __metafn_is_enumerator_spec,
+  __metafn_define_enum,
+  __metafn_reflect_enumerator,
 
   // Other bespoke functions (not proposed at this time)
   __metafn_is_access_specified,
@@ -2152,6 +2156,10 @@ consteval auto has_attribute(
   attribute_comparison policy
 ) -> bool {
   return __metafunction(detail::__metafn_has_attribute, entity, attribute, policy);
+}
+
+consteval info reflect_enumerator(info r) {
+  return __metafunction(detail::__metafn_reflect_enumerator, r);
 }
 
 // Returns whether the reflected entity is a clang scoped attribute.


### PR DESCRIPTION

**Describe your changes**
Reflect the source enumerator initializing an enum typed variable

**Testing performed**
```cpp

enum Level {
        e_OFF [[=1]]  =   0, 
        e_FATAL =  32,
        e_ERROR =  64,
// ....
      , BAEL_OFF   = e_OFF
      , BAEL_FATAL = e_FATAL
      , BAEL_ERROR = e_ERROR
};

constexpr Level lvl = Level::e_OFF;
static_assert(std::meta::reflect_enumerator(^^lvl) == ^^Level::e_OFF);
static_assert(std::meta::reflect_enumerator(^^lvl) != ^^Level::BAEL_OFF);
static_assert(std::meta::annotations_of(std::meta::reflect_enumerator(^^lvl)).size() == 1);

constexpr Level lvl2 = Level::BAEL_OFF;
static_assert(std::meta::annotations_of(std::meta::reflect_enumerator(^^lvl2)).size() == 0);
```

**Additional context**
Early draft