### PR TITLE
[clang][reflection] Discriminate same-named function-template reflections in NTTP mangling

### DIFF
--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -29,6 +29,7 @@
 #include "clang/AST/ExprObjC.h"
 #include "clang/AST/LocInfoType.h"
 #include "clang/AST/Mangle.h"
+#include "clang/AST/ODRHash.h"
 #include "clang/AST/TypeLoc.h"
 #include "clang/Basic/ABI.h"
 #include "clang/Basic/Module.h"
@@ -5021,8 +5022,29 @@ void CXXNameMangler::mangleReflection(const APValue &R) {
   case ReflectionKind::Template: {
     Out << 't';
 
+    TemplateDecl *TD = R.getReflectedTemplate().getAsTemplateDecl();
     ArrayRef<TemplateArgument> Args;
-    mangleTemplateName(R.getReflectedTemplate().getAsTemplateDecl(), Args);
+    mangleTemplateName(TD, Args);
+    // The name alone identifies class/variable/alias templates, but function
+    // templates OVERLOAD: two same-named siblings (e.g. absl raw_hash_map's
+    // lifetimebound operator[] pair) mangled identically here, so a template
+    // taking the reflection as an NTTP got ONE mangled name for its two
+    // specializations -- CodeGen then silently folds the linkonce_odr
+    // definitions and a single body serves both call sites (the AST-level
+    // specializations are correct and distinct; no diagnostic anywhere). Append a structural
+    // digest of the template head + declaration pattern to discriminate the
+    // overloads. An ODR hash (cross-TU-stable by design; it is how modules
+    // compare decls between TUs) rather than a structural mangling of the
+    // pattern's function type: dependent pattern types from real code embed
+    // parameter-referencing expressions (lifetimebound SFINAE, noexcept(...))
+    // that the mangler cannot encode outside a function-declaration context
+    // (mangleFunctionParam asserts).
+    if (auto *FTD = dyn_cast<FunctionTemplateDecl>(TD)) {
+      ODRHash Hash;
+      Hash.AddTemplateParameterList(FTD->getTemplateParameters());
+      Hash.AddFunctionDecl(FTD->getTemplatedDecl(), /*SkipBody=*/true);
+      Out << '$' << Hash.CalculateHash() << '$';
+    }
     break;
   }
   case ReflectionKind::Namespace: {

--- a/libcxx/test/std/experimental/reflection/substitute-nested-dependent.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/substitute-nested-dependent.pass.cpp
@@ -1,0 +1,103 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright 2024 Bloomberg Finance L.P.
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03 || c++11 || c++14 || c++17 || c++20
+// ADDITIONAL_COMPILE_FLAGS: -freflection-latest
+
+// <experimental/reflection>
+//
+// [reflection]
+//
+// Regression test: reflections of same-named (overloaded) function templates
+// used as non-type template arguments must produce DISTINCT specializations
+// all the way through codegen. Previously the Itanium mangling for a
+// ReflectionKind::Template encoded only the template's name, so a dispatcher
+// like fn_probe<T, tmpl> below got one mangled name for its two
+// instantiations; CodeGen silently folded the linkonce_odr definitions, and a
+// single body (here: the SFINAE-false pack sibling's) served both call sites.
+// The AST-level specializations were always correct, so only a RUNTIME
+// observation catches this.
+
+#include <meta>
+
+#include <cassert>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+template <bool C> using EnableIf = std::enable_if_t<C, int>;
+template <class K, bool V> inline constexpr bool LTB = !V;
+
+struct B {
+  // Instantiable with zero explicit arguments (every parameter defaulted).
+  template <class K = int, class P = double, int = EnableIf<LTB<K, false>>()>
+  std::string& operator[](K&& k);
+  // SFINAE-false pack sibling: same name, never instantiable.
+  template <class K = int, class P = double, int&..., EnableIf<LTB<K, true>> = 0>
+  std::string& operator[](K&& k);
+};
+
+consteval bool can_sub0(std::meta::info tmpl) {
+  return std::meta::can_substitute(tmpl, std::vector<std::meta::info>{});
+}
+consteval std::meta::info sub0(std::meta::info tmpl) {
+  return std::meta::substitute(tmpl, std::vector<std::meta::info>{});
+}
+consteval int member_index(std::meta::info cls, std::meta::info fn) {
+  int i = 0;
+  for (auto m : std::meta::members_of(cls, std::meta::access_context::unchecked())) {
+    if (m == fn) return i;
+    ++i;
+  }
+  return -1;
+}
+
+// The probe: substitute() two dependent levels deep (called from a `template
+// for` body in fn_driver). Encodes which template it was instantiated for and
+// whether it substituted into its return value.
+template <typename T, std::meta::info tmpl>
+int fn_probe() {
+  if constexpr (can_sub0(tmpl)) {
+    constexpr auto spec = sub0(tmpl);
+    static_assert(std::meta::is_operator_function(spec));
+    static_assert(!std::meta::is_volatile(spec));
+    static_assert(!std::meta::is_rvalue_reference_qualified(spec));
+    return member_index(^^T, tmpl) * 10 + 1;
+  } else {
+    return member_index(^^T, tmpl) * 10;
+  }
+}
+
+template <typename T>
+void fn_driver() {
+  int results[2];
+  int (*addrs[2])();
+  int n = 0;
+  template for (constexpr auto fn : std::define_static_array(
+          std::meta::members_of(^^T, std::meta::access_context::unchecked()))) {
+    if constexpr (std::meta::is_function_template(fn)) {
+      results[n] = fn_probe<T, fn>();
+      addrs[n] = &fn_probe<T, fn>;
+      ++n;
+    }
+  }
+  assert(n == 2);
+  // Distinct specializations: under the mangling collision these were one
+  // folded symbol, so the addresses compared equal and one body ran twice.
+  assert(addrs[0] != addrs[1]);
+  // member#0 substitutes (0 * 10 + 1), the pack sibling does not (1 * 10).
+  assert(results[0] == 1);
+  assert(results[1] == 10);
+}
+
+int main() {
+  fn_driver<B>();
+  return 0;
+}


### PR DESCRIPTION
Fixes #286.

## Problem

`mangleReflection`'s `ReflectionKind::Template` case encodes only the reflected template's name. Function templates overload, so reflections of same-named sibling templates mangle byte-identically; a function template taking such a reflection as an NTTP gets one mangled name for two distinct specializations, and CodeGen silently folds the linkonce_odr definitions — a single body serves both call sites, with correct AST and no diagnostic. Full analysis, field impact (`absl::flat_hash_map`'s `operator[]` silently dropped by a reflection-driven binding generator), and a standalone repro are in #286.

## Fix

For `FunctionTemplateDecl` reflections only, append a `$`-bracketed ODR hash of the template parameter list + the templated declaration pattern after the template name. The ODR hash is cross-TU-stable by design (modules rely on it to compare decls across TUs), so legitimate cross-TU linkonce_odr merging is preserved. Other template kinds are unchanged (they cannot overload, so the name suffices).

A structural encoding (mangling the template head via `mangleTemplateParamDecl` + the pattern's function type) was tried first and abandoned: dependent pattern types from real-world code (Abseil's lifetimebound SFINAE, `noexcept(...)` referencing parameters) embed `ParmVarDecl`-referencing expressions that `mangleFunctionParam` cannot encode outside a function-declaration context (`parmDepth < FunctionTypeDepth.getDepth()` assertion). Happy to rework toward a structural encoding if that's preferred and the assertion path is addressed.

## Test

`libcxx/test/std/experimental/reflection/substitute-nested-dependent.pass.cpp` reproduces the dispatcher shape (two same-named member `operator[]` templates, one SFINAE-false pack sibling, dispatched as NTTPs from a `template for` over `members_of`) and asserts **at runtime** that the two instantiations are distinct functions executing their own bodies (address inequality + per-body results). `static_assert`s cannot catch this bug: the AST-level specializations were always correct; only codegen folded them.

## Validation

- Base: `837da39eb88c` (current `p2996` tip; the commit applies cleanly there).
- `clang/test/Reflection`: 16/16 pass with the change (Release+assertions, AArch64/macOS).
- The new `.pass.cpp` fails before the change (asserts: both addresses equal, sibling body ran twice) and passes after.
- Downstream soak: a reflection-driven nanobind binding generator's 50-test suite plus 17 real-library binding runs (Abseil containers/strings/time/status, fmt, nlohmann/json, glm, linalg) all pass against a toolchain carrying this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
