### PR TITLE
[clang][reflection] Fix use-after-free: ExprEvalContexts reallocates under held record references during reentrant consteval evaluation

### DIFF
--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -18052,13 +18052,29 @@ HandleImmediateInvocations(Sema &SemaRef,
   // side-effects may introduce additional invocation candidates, thereby
   // invalidating the iterator.
   //
+  // Moreover, evaluating an immediate invocation can recursively push (and pop)
+  // expression evaluation contexts via nested template instantiation. If that
+  // reallocates Sema::ExprEvalContexts (a SmallVector), the `Rec` reference —
+  // which aliases ExprEvalContexts.back() — is left dangling, a use-after-free
+  // surfacing later in PopExpressionEvaluationContext as a crash on garbage
+  // (e.g. heavy P2996 reflection over a large value type). Re-acquire the record
+  // through currentEvaluationContext() on each access; our record stays the top
+  // of the stack throughout (nested contexts are balanced).
+  //
   // TODO(P2996): Can we avoid this?
-  for (size_t Idx = 0; Idx < Rec.ImmediateInvocationCandidates.size(); ++Idx) {
-    auto CE = Rec.ImmediateInvocationCandidates[Idx];
+  for (size_t Idx = 0;
+       Idx < SemaRef.currentEvaluationContext().ImmediateInvocationCandidates.size();
+       ++Idx) {
+    auto CE =
+        SemaRef.currentEvaluationContext().ImmediateInvocationCandidates[Idx];
     if (!CE.getInt() && !CE.getPointer()->isValueDependent())
       EvaluateAndDiagnoseImmediateInvocation(SemaRef, CE);
   }
-  for (auto *DR : Rec.ReferenceToConsteval) {
+  // Re-acquire after the reentrant evaluation above (see note); `Rec` may now be
+  // dangling. The trailing loops below do not themselves reenter.
+  Sema::ExpressionEvaluationContextRecord &CurRec =
+      SemaRef.currentEvaluationContext();
+  for (auto *DR : CurRec.ReferenceToConsteval) {
     // If the expression is immediate escalating, it is not an error;
     // The outer context itself becomes immediate and further errors,
     // if any, will be handled by DiagnoseImmediateEscalatingReason.
@@ -18077,14 +18093,14 @@ HandleImmediateInvocations(Sema &SemaRef,
     // that is not a subexpression of an immediate invocation.
     bool ImmediateEscalating = false;
     bool IsPotentiallyEvaluated =
-        Rec.Context ==
+        CurRec.Context ==
             Sema::ExpressionEvaluationContext::PotentiallyEvaluated ||
-        Rec.Context ==
+        CurRec.Context ==
             Sema::ExpressionEvaluationContext::PotentiallyEvaluatedIfUsed;
     if (SemaRef.inTemplateInstantiation() && IsPotentiallyEvaluated)
-      ImmediateEscalating = Rec.InImmediateEscalatingFunctionContext;
+      ImmediateEscalating = CurRec.InImmediateEscalatingFunctionContext;
 
-    if (!Rec.InImmediateEscalatingFunctionContext ||
+    if (!CurRec.InImmediateEscalatingFunctionContext ||
         (SemaRef.inTemplateInstantiation() && !ImmediateEscalating)) {
       SemaRef.Diag(DR->getBeginLoc(), diag::err_invalid_consteval_take_address)
           << ND << isa<CXXRecordDecl>(ND) << FD->isConsteval();
@@ -18103,20 +18119,20 @@ HandleImmediateInvocations(Sema &SemaRef,
       SemaRef.MarkExpressionAsImmediateEscalating(DR);
     }
   }
-  for (auto *E : Rec.ConstevalOnly) {
+  for (auto *E : CurRec.ConstevalOnly) {
     if (E->isImmediateEscalating())
       continue;
 
     bool ImmediateEscalating = false;
     bool IsPotentiallyEvaluated =
-        Rec.Context ==
+        CurRec.Context ==
             Sema::ExpressionEvaluationContext::PotentiallyEvaluated ||
-        Rec.Context ==
+        CurRec.Context ==
             Sema::ExpressionEvaluationContext::PotentiallyEvaluatedIfUsed;
     if (SemaRef.inTemplateInstantiation() && IsPotentiallyEvaluated)
-      ImmediateEscalating = Rec.InImmediateEscalatingFunctionContext;
+      ImmediateEscalating = CurRec.InImmediateEscalatingFunctionContext;
 
-    if (!Rec.InImmediateEscalatingFunctionContext ||
+    if (!CurRec.InImmediateEscalatingFunctionContext ||
         (SemaRef.inTemplateInstantiation() && !ImmediateEscalating)) {
       SemaRef.Diag(E->getExprLoc(), diag::err_expr_consteval_only_type)
           << E->getSourceRange();
@@ -18170,10 +18186,16 @@ void Sema::PopExpressionEvaluationContext() {
   WarnOnPendingNoDerefs(Rec);
   HandleImmediateInvocations(*this, Rec);
 
+  // HandleImmediateInvocations may have evaluated immediate invocations that
+  // recursively pushed/popped expression evaluation contexts, reallocating
+  // ExprEvalContexts and invalidating `Rec`. Re-acquire the record (still the
+  // top of the stack) before any further use; do not touch `Rec` below.
+  ExpressionEvaluationContextRecord &TailRec = ExprEvalContexts.back();
+
   // Warn on any volatile-qualified simple-assignments that are not discarded-
   // value expressions nor unevaluated operands (those cases get removed from
   // this list by CheckUnusedVolatileAssignment).
-  for (auto *BO : Rec.VolatileAssignmentLHSs)
+  for (auto *BO : TailRec.VolatileAssignmentLHSs)
     Diag(BO->getBeginLoc(), diag::warn_deprecated_simple_assign_volatile)
         << BO->getType();
 
@@ -18181,16 +18203,19 @@ void Sema::PopExpressionEvaluationContext() {
   // temporaries that we may have created as part of the evaluation of
   // the expression in that context: they aren't relevant because they
   // will never be constructed.
-  if (Rec.isUnevaluated() || Rec.isConstantEvaluated()) {
-    ExprCleanupObjects.erase(ExprCleanupObjects.begin() + Rec.NumCleanupObjects,
-                             ExprCleanupObjects.end());
-    Cleanup = Rec.ParentCleanup;
+  if (TailRec.isUnevaluated() || TailRec.isConstantEvaluated()) {
+    ExprCleanupObjects.erase(
+        ExprCleanupObjects.begin() + TailRec.NumCleanupObjects,
+        ExprCleanupObjects.end());
+    Cleanup = TailRec.ParentCleanup;
     CleanupVarDeclMarking();
-    std::swap(MaybeODRUseExprs, Rec.SavedMaybeODRUseExprs);
+    // CleanupVarDeclMarking() may itself instantiate and reallocate
+    // ExprEvalContexts; re-acquire before reading SavedMaybeODRUseExprs.
+    std::swap(MaybeODRUseExprs, ExprEvalContexts.back().SavedMaybeODRUseExprs);
   // Otherwise, merge the contexts together.
   } else {
-    Cleanup.mergeFrom(Rec.ParentCleanup);
-    MaybeODRUseExprs.insert_range(Rec.SavedMaybeODRUseExprs);
+    Cleanup.mergeFrom(TailRec.ParentCleanup);
+    MaybeODRUseExprs.insert_range(TailRec.SavedMaybeODRUseExprs);
   }
 
   // Pop the current expression evaluation context off the stack.
@@ -20008,9 +20033,9 @@ ExprResult Sema::CheckLValueToRValueConversionOperand(Expr *E) {
   if (E->getType().isVolatileQualified() || E->getType()->getAs<RecordType>())
     return E;
 
-  auto &CEO = ExprEvalContexts.back().ConstevalOnly;
-  bool ReplaceConstevalOnly = E->getType()->isConstevalOnly() &&
-                              CEO.find(E) != CEO.end();
+  bool ReplaceConstevalOnly =
+      E->getType()->isConstevalOnly() &&
+      ExprEvalContexts.back().ConstevalOnly.contains(E);
 
   ExprResult Result =
       rebuildPotentialResultsAsNonOdrUsed(*this, E, NOUR_Constant);
@@ -20019,7 +20044,13 @@ ExprResult Sema::CheckLValueToRValueConversionOperand(Expr *E) {
 
   Result = Result.get() ? Result : E;
   if (ReplaceConstevalOnly)
-    CEO.insert(Result.get());
+    // Do not cache a reference to ConstevalOnly across the rebuild above: it
+    // can mark declarations used and trigger instantiation, which pushes
+    // expression evaluation contexts and may reallocate ExprEvalContexts,
+    // leaving such a reference dangling (same family as the reentrant
+    // consteval use-after-free fixed in PopExpressionEvaluationContext /
+    // HandleImmediateInvocations).
+    ExprEvalContexts.back().ConstevalOnly.insert(Result.get());
   return Result;
 }
 

--- a/libcxx/test/std/experimental/reflection/consteval-reentrant-instantiation.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/consteval-reentrant-instantiation.pass.cpp
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright 2024 Bloomberg Finance L.P.
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03 || c++11 || c++14 || c++17 || c++20
+// ADDITIONAL_COMPILE_FLAGS: -freflection-latest
+
+// <experimental/reflection>
+//
+// [reflection]
+//
+// Regression test: evaluating a deferred immediate invocation may REENTER Sema
+// through reflection metafunctions — substitute() instantiates the named
+// specialization (and, for an undeduced signature, its body), and each nested
+// instantiation pushes expression evaluation contexts. Sema used to hold a
+// reference into ExprEvalContexts (a SmallVector) across that evaluation in
+// PopExpressionEvaluationContext / HandleImmediateInvocations; once the vector
+// reallocated, the reference dangled — a use-after-free whose crash was heap-
+// layout dependent (deterministic under allocators that scribble freed memory,
+// e.g. macOS MallocScribble=1, or ASan).
+//
+// This test builds a 64-deep instantiation cascade that runs entirely inside
+// the deferred evaluation: start(n) takes its depth as an evaluation-time
+// value, so nothing instantiates at parse time, and chain<N>'s deduced return
+// type forces substitute() to instantiate each body, whose dependent
+// splice-of-substitute recurses one level deeper. The stack of evaluation
+// contexts crosses several SmallVector growth thresholds while the popped
+// record is held.
+
+#include <meta>
+
+#include <cassert>
+#include <vector>
+
+template <int N>
+consteval auto chain() {  // deduced return type => substitute() instantiates the body
+  if constexpr (N <= 0) {
+    return 0;
+  } else {
+    return [:std::meta::substitute(
+        ^^chain,
+        std::vector<std::meta::info>{std::meta::reflect_constant(N - 1)}):]() + 1;
+  }
+}
+
+consteval int start(int n) {
+  return std::meta::extract<int (*)()>(std::meta::substitute(
+      ^^chain, std::vector<std::meta::info>{std::meta::reflect_constant(n)}))();
+}
+
+int main() {
+  // Runtime context: start(64) is deferred as an immediate-invocation candidate
+  // and evaluated during PopExpressionEvaluationContext.
+  int x = start(64);
+  assert(x == 64);
+  return 0;
+}


### PR DESCRIPTION
Fixes #288.

## Problem

`Sema::PopExpressionEvaluationContext` holds `ExpressionEvaluationContextRecord &Rec = ExprEvalContexts.back()` across `HandleImmediateInvocations`, which constant-evaluates the popped context's pending immediate invocations. With reflection, that evaluation reenters Sema — `substitute()` instantiates the named specialization (and, for undeduced signatures, its body via `MetaActions::Substitute`), and the evaluator's `EnsureInstantiated` hook instantiates definitions for calls — and every nested instantiation pushes/pops expression evaluation contexts. When `ExprEvalContexts` (a `SmallVector<..., 8>`) reallocates, `Rec` and every other reference into the old storage dangle: a use-after-free read in `PopExpressionEvaluationContext`'s tail and `HandleImmediateInvocations`' trailing loops. Field crash, mechanism analysis, and a standalone reproducer are in #288. (The candidate loop already iterates by index because evaluation can grow the *candidate vector* — the `NOTE(P2996)` — this is the same hazard one level up.)

## Fix

Re-acquire the record instead of holding a reference across any reentrant evaluation. The record is always the top of the stack — nested contexts are balanced — only its address can move:

- `HandleImmediateInvocations`: fetch via `currentEvaluationContext()` per access in the candidate-evaluation loop; re-acquire once after it for the trailing diagnostics loops (which do not themselves reenter).
- `PopExpressionEvaluationContext`: re-acquire `ExprEvalContexts.back()` after `HandleImmediateInvocations` for the tail, and again after `CleanupVarDeclMarking()` (which can also instantiate).
- `CheckLValueToRValueConversionOperand`: found by auditing every reference held into `ExprEvalContexts` — it bound `auto &CEO = ExprEvalContexts.back().ConstevalOnly` before `rebuildPotentialResultsAsNonOdrUsed()` and inserted through it afterwards; the rebuild can mark declarations used and trigger instantiation. Re-acquire after the rebuild.

## Test

`libcxx/test/std/experimental/reflection/consteval-reentrant-instantiation.pass.cpp` — a 64-deep instantiation cascade that runs entirely inside a deferred immediate invocation's evaluation (the depth is an evaluation-time value, so nothing instantiates at parse time; the `auto`-returning template forces body instantiation per `substitute()`, recursing through a dependent splice-of-substitute). It crosses several `SmallVector` growth thresholds while the popped record is held.

## Validation

- Base: `837da39eb88c` (current `p2996` tip; applies cleanly).
- Without the fix: an address probe (`&ExprEvalContexts.back()` compared across `HandleImmediateInvocations`) fires on every compile of the test; `MallocScribble=1` (macOS) crashes **5/5** with SIGSEGV inside `Sema::PopExpressionEvaluationContext` — the exact field-crash frame; plain runs corrupt silently (0/10 crashes — heap-layout luck), matching the original non-deterministic field behavior. ASan bots should catch regressions deterministically.
- With the fix: test passes, including under `MallocScribble=1`.
- `clang/test/Reflection`: 16/16 (Release+assertions, AArch64/macOS).
- Downstream soak: the original field trigger (`nlohmann::json` reflected end-to-end, ~17s at `-fconstexpr-steps=20M`) plus a reflection-driven nanobind binding generator's 50-test suite and 17 real-library binding runs all pass on a toolchain carrying this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
