### PR TITLE
[clang][reflection] Handle entity-proxy reflections in member metafunctions and NTTP mangling

### DIFF
--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -4560,7 +4560,10 @@ bool is_static_member(APValue &Result, ASTContext &C, MetaActions &Meta,
   case ReflectionKind::Attribute:
     return SetAndSucceed(Result, makeBool(C, result));
   case ReflectionKind::EntityProxy:
-    llvm_unreachable("proxies should already have been unwrapped");
+    // A using-shadow declaration is never itself one of these; member
+    // enumeration under -fentity-proxy-reflection may legitimately query it
+    // (crashing here turned a valid consteval query into an ICE).
+    return SetAndSucceed(Result, makeBool(C, false));
   }
   llvm_unreachable("unknown reflection kind");
 }
@@ -4784,9 +4787,11 @@ bool has_complete_definition(APValue &Result, ASTContext &C, MetaActions &Meta,
   case ReflectionKind::DataMemberSpec:
   case ReflectionKind::Annotation:
   case ReflectionKind::Attribute:
-    break;
+  // A using-shadow declaration is not itself a definable entity; member
+  // enumeration under -fentity-proxy-reflection may legitimately query it
+  // (crashing here turned a valid consteval query into an ICE).
   case ReflectionKind::EntityProxy:
-    llvm_unreachable("proxies should already have been unwrapped");
+    break;
   }
 
   return SetAndSucceed(Result, makeBool(C, result));
@@ -4825,9 +4830,11 @@ bool is_enumerable_type(APValue &Result, ASTContext &C, MetaActions &Meta,
   case ReflectionKind::DataMemberSpec:
   case ReflectionKind::Annotation:
   case ReflectionKind::Attribute:
-    break;
+  // A using-shadow declaration is not itself an enumerable type; member
+  // enumeration under -fentity-proxy-reflection may legitimately query it
+  // (crashing here turned a valid consteval query into an ICE).
   case ReflectionKind::EntityProxy:
-    llvm_unreachable("proxies should already have been unwrapped");
+    break;
   }
 
   return SetAndSucceed(Result, makeBool(C, result));
@@ -5237,7 +5244,10 @@ bool is_constructor(APValue &Result, ASTContext &C, MetaActions &Meta,
     return SetAndSucceed(Result, makeBool(C, result));
   }
   case ReflectionKind::EntityProxy:
-    llvm_unreachable("proxies should already have been unwrapped");
+    // A using-shadow declaration is never itself a constructor; callers
+    // enumerating members under -fentity-proxy-reflection may legitimately
+    // query it (crashing here turned a valid consteval query into an ICE).
+    return SetAndSucceed(Result, makeBool(C, false));
   }
   llvm_unreachable("invalid reflection type");
 }
@@ -5388,7 +5398,10 @@ bool is_destructor(APValue &Result, ASTContext &C, MetaActions &Meta,
     return SetAndSucceed(Result, makeBool(C, result));
   }
   case ReflectionKind::EntityProxy:
-    llvm_unreachable("proxies should already have been unwrapped");
+    // A using-shadow declaration is never itself one of these; member
+    // enumeration under -fentity-proxy-reflection may legitimately query it
+    // (crashing here turned a valid consteval query into an ICE).
+    return SetAndSucceed(Result, makeBool(C, false));
   }
   llvm_unreachable("invalid reflection type");
 }
@@ -5432,7 +5445,10 @@ bool is_special_member_function(APValue &Result, ASTContext &C,
     return SetAndSucceed(Result, makeBool(C, result));
   }
   case ReflectionKind::EntityProxy:
-    llvm_unreachable("proxies should already have been unwrapped");
+    // A using-shadow declaration is never itself one of these; member
+    // enumeration under -fentity-proxy-reflection may legitimately query it
+    // (crashing here turned a valid consteval query into an ICE).
+    return SetAndSucceed(Result, makeBool(C, false));
   }
   llvm_unreachable("invalid reflection type");
 }

--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -5035,7 +5035,30 @@ void CXXNameMangler::mangleReflection(const APValue &R) {
   }
   case ReflectionKind::EntityProxy: {
     Out << 'a';
-    mangleNameWithAbiTags(R.getReflectedEntityProxy(), nullptr);
+    // Mangling the shadow declaration itself (mangleNameWithAbiTags) trips a
+    // cast<> assertion when the shadow lives in a class template
+    // specialization (e.g. a `using OperatorBase<T>::value;` re-export inside
+    // an instantiated class). Mangle the proxy's TARGET declaration instead,
+    // mirroring the Declaration case above; the 'a' tag keeps a proxy-of-X
+    // distinct from a declaration-of-X reflection.
+    NamedDecl *Target = R.getReflectedEntityProxy()->getTargetDecl();
+    if (auto *ED = dyn_cast<EnumConstantDecl>(Target)) {
+      mangleIntegerLiteral(ED->getType(), ED->getInitVal());
+    } else if (auto *CD = dyn_cast<CXXConstructorDecl>(Target)) {
+      GlobalDecl GD(CD, Ctor_Complete);
+      mangle(GD);
+    } else if (auto *DD = dyn_cast<CXXDestructorDecl>(Target)) {
+      GlobalDecl GD(DD, Dtor_Complete);
+      mangle(GD);
+    } else if (isa<FunctionDecl, VarDecl, FieldDecl>(Target)) {
+      mangle(Target);
+    } else if (auto *TD = dyn_cast<TypeDecl>(Target)) {
+      Context.mangleCanonicalTypeName(getASTContext().getTypeDeclType(TD), Out,
+                                      false);
+    } else if (IdentifierInfo *II = Target->getIdentifier()) {
+      // Last resort for target kinds mangle() cannot encode: the source name.
+      mangleSourceName(II);
+    }
     Out << '$';
     break;
   }

--- a/libcxx/test/std/experimental/reflection/entity-proxy-member-queries.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/entity-proxy-member-queries.pass.cpp
@@ -1,0 +1,142 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright 2024 Bloomberg Finance L.P.
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03 || c++11 || c++14 || c++17 || c++20
+// ADDITIONAL_COMPILE_FLAGS: -freflection-latest
+// ADDITIONAL_COMPILE_FLAGS: -fentity-proxy-reflection
+
+// <experimental/reflection>
+//
+// [reflection]
+//
+// Regression test: with -fentity-proxy-reflection, members_of enumerates
+// using-shadow declarations as EntityProxy reflections, so ordinary member
+// queries reach them directly. Several consumers used to treat that kind as
+// llvm_unreachable("proxies should already have been unwrapped"):
+//
+//   * is_constructor / is_destructor / is_special_member_function /
+//     is_static_member / is_enumerable_type / has_complete_definition ICEd
+//     when asked of a proxy. They now answer false, consistent with how the
+//     other kind predicates already classify proxies (a shadow declaration is
+//     never itself one of these; query the underlying entity for its
+//     properties via underlying_entity_of).
+//   * The Itanium mangler encoded a proxy reflection as a template argument
+//     by mangling the shadow declaration's NAME (mangleNameWithAbiTags).
+//     Two defects followed: (1) an operator-named shadow (using B::operator*)
+//     crashed outright -- mangleUnqualifiedName casts the decl to
+//     FunctionDecl to disambiguate the operator name, and a UsingShadowDecl
+//     is not one (cast<> assertion); (2) one using-declarator over an
+//     overload set introduces several same-named shadows whose proxies all
+//     mangled identically ("definition with same mangled name" at best, a
+//     silent CodeGen fold at worst). The mangler now encodes the proxy's
+//     TARGET declaration, keeping the proxy tag so proxy-of-X and
+//     declaration-of-X reflections remain distinct template arguments
+//     through codegen.
+
+#include <meta>
+
+#include <cassert>
+
+constexpr auto unchecked = std::meta::access_context::unchecked();
+
+// ===== Part 1: member-kind queries on proxies (used to be unreachable) =====
+
+struct B {
+  int f() const { return 1; }
+  static int g() { return 2; }
+  static int s;
+  int field;
+  using T = int;
+  struct N {};
+};
+
+struct D : private B {
+  using B::f;
+  using B::g;
+  using B::s;
+  using B::field;
+  using B::T;
+  using B::N;
+};
+
+consteval bool check_member_queries() {
+  int proxies = 0;
+  for (auto m : members_of(^^D, unchecked)) {
+    if (!is_entity_proxy(m))
+      continue;
+    ++proxies;
+
+    // A using-shadow declaration is never itself any of these.
+    if (is_constructor(m) || is_destructor(m) ||
+        is_special_member_function(m) || is_static_member(m))
+      return false;
+    if (is_enumerable_type(m))
+      return false;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    if (has_complete_definition(m))
+      return false;
+#pragma clang diagnostic pop
+  }
+  // One proxy per using-declarator above.
+  return proxies == 6;
+}
+static_assert(check_member_queries());
+
+// ===== Part 2: proxy reflections as template arguments through codegen =====
+
+template <class T> struct OB {
+  // One using-declarator over this overload set introduces FOUR same-named
+  // shadows: their proxies must not collide as template arguments.
+  int value() & { return 1; }
+  int value() const & { return 2; }
+  int value() && { return 3; }
+  int value() const && { return 4; }
+  // An operator-named shadow crashed the mangler outright (this is the shape
+  // absl::StatusOr's `using StatusOr::OperatorBase::operator*;` hits).
+  int operator*() const { return 5; }
+};
+
+template <class T> struct S : private OB<T> {
+  using OB<T>::value;
+  using OB<T>::operator*;
+};
+
+template <std::meta::info M> int probe() { return 7; }
+
+void check_proxy_as_template_arg() {
+  int n = 0;
+  int total = 0;
+  const void *proxy_addrs[5] = {};
+  template for (constexpr auto m : std::define_static_array(
+          members_of(^^S<int>, unchecked))) {
+    if constexpr (is_entity_proxy(m)) {
+      total += probe<m>();
+      proxy_addrs[n] = reinterpret_cast<const void *>(&probe<m>);
+      // A proxy-of-X must not collide with the declaration-of-X reflection
+      // (the proxy tag in the mangling): otherwise CodeGen silently folds.
+      assert(proxy_addrs[n] !=
+             reinterpret_cast<const void *>(&probe<underlying_entity_of(m)>));
+      ++n;
+    }
+  }
+  assert(n == 5);
+  assert(total == 35);
+  // Every proxy must remain its own specialization: the four same-named
+  // value() shadows and the operator* shadow are five distinct entities.
+  for (int i = 0; i < n; ++i)
+    for (int j = i + 1; j < n; ++j)
+      assert(proxy_addrs[i] != proxy_addrs[j]);
+}
+
+int main() {
+  check_proxy_as_template_arg();
+  return 0;
+}


### PR DESCRIPTION
Fixes #290.

## Problem

With `-fentity-proxy-reflection`, `members_of` enumerates using-shadow declarations as `ReflectionKind::EntityProxy`, so proxy reflections flow directly into ordinary consteval member queries and, as `std::meta::info` NTTPs, into the Itanium mangler. Several consumers still treated that kind as `llvm_unreachable("proxies should already have been unwrapped")`, turning valid code into ICEs (see #290 for self-contained reproducers and crash signatures).

## Fix

- **`clang/lib/AST/ExprConstantMeta.cpp`** — six metafunctions crashed when asked of a proxy: `is_constructor`, `is_destructor`, `is_special_member_function`, `is_static_member`, `is_enumerable_type`, `has_complete_definition`. Each now answers `false`, consistent with how the surrounding kind predicates already classify proxies (a shadow declaration is never itself one of these; the underlying entity's properties are available through `underlying_entity_of`). The remaining unreachable proxy arms were probed NOT reachable from user code (`identifier_of`/`has_identifier`/`source_location_of` pre-unwrap via `MaybeUnproxy`; `substitute`'s dispatcher unwraps template arguments before `TArgFromReflection`; `reflect_invoke` through a proxy fails gracefully as not-a-constant-expression) and are left as-is.
- **`clang/lib/AST/ItaniumMangle.cpp`** — `mangleReflection`'s `EntityProxy` case encoded the proxy by mangling the shadow declaration's NAME (`mangleNameWithAbiTags`), with two defects: an operator-named shadow (e.g. `using OB::operator*;`, the shape `absl::StatusOr<T>` hits via `using StatusOr::OperatorBase::operator*;`) crashed outright (`mangleUnqualifiedName` casts the decl to `FunctionDecl` to disambiguate the operator name — `cast<>` assertion), and one using-declarator over an overload set introduced several same-named shadows whose proxies all mangled identically ("definition with same mangled name" at best, a silent linkonce_odr fold at worst). The mangler now encodes the proxy's TARGET declaration kind-aware (ctors/dtors via `GlobalDecl`, functions/variables/fields via `mangle()`, enum constants as literals, types via `mangleCanonicalTypeName`, else the source name), keeping the `a` tag so a proxy-of-X reflection stays a distinct template argument from a declaration-of-X reflection.

## Test

- `libcxx/test/std/experimental/reflection/entity-proxy-member-queries.pass.cpp` (new): a consteval sweep of all six metafunctions over proxies of every member kind — member function, static member function, static data member, field, type alias, nested class (each call ICEd before the fix) — plus runtime distinctness assertions for proxy NTTPs: an operator shadow and a four-overload `value()` shadow set from a class template specialization, asserting every proxy instantiation is distinct from its siblings and from its underlying declaration's instantiation (`static_assert` cannot catch a mangling fold).

## Validation

- Base: `837da39eb88c` (current `p2996` tip; applies cleanly).
- Without the fix: each of the six metafunction calls independently hits the UNREACHABLE (`ExprConstantMeta.cpp:5240/5391/5435/4563/4830/4789`); the operator-shadow NTTP asserts in `mangleUnqualifiedName`; the overload-set NTTP errors with `definition with same mangled name '_Z5probeIMaN1SIiE5valueE$EEiv'`; the new test ICEs.
- With the fix: reproducers and the new test compile and run clean.
- `clang/test/Reflection`: 15/16 both at base and with the fix — identical results; the one failure (`splice-exprs.cpp`) is pre-existing at base and unrelated.
- Downstream soak (reflection-driven nanobind binding generator): 50-test binder suite with all modules recompiled, plus real-library corpus runs including `absl::StatusOr` (the field trigger: its `using StatusOr::OperatorBase::value/operator*/operator->;` re-exports) and nlohmann/json — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
