### PR TITLE
[clang][reflection] Desugar function types in metafunctions: attributes on a declarator blinded qualifier and signature queries

### DIFF
--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -1597,7 +1597,11 @@ static bool isFunctionOrMethodNoexcept(const QualType QT) {
 
 static bool isConstQualifiedType(QualType QT) {
   bool result = QT.isConstQualified();
-  if (auto *FPT = dyn_cast<FunctionProtoType>(QT))
+  // getAs, not dyn_cast: attributes on a function declarator (e.g.
+  // [[clang::lifetimebound]] on the implicit object parameter) wrap the
+  // FunctionProtoType in AttributedType sugar that dyn_cast cannot see
+  // through, silently dropping the method qualifiers.
+  if (const auto *FPT = QT->getAs<FunctionProtoType>())
     result |= FPT->isConst();
 
   return result;
@@ -1605,7 +1609,7 @@ static bool isConstQualifiedType(QualType QT) {
 
 static bool isVolatileQualifiedType(QualType QT) {
   bool result = QT.isVolatileQualified();
-  if (auto *FPT = dyn_cast<FunctionProtoType>(QT))
+  if (const auto *FPT = QT->getAs<FunctionProtoType>())
     result |= FPT->isVolatile();
 
   return result;
@@ -4226,11 +4230,11 @@ bool is_lvalue_reference_qualified(APValue &Result, ASTContext &C,
 
   bool result = false;
   if (RV.isReflectedType()) {
-    if (auto FT = dyn_cast<FunctionProtoType>(RV.getReflectedType()))
+    if (const auto *FT = RV.getReflectedType()->getAs<FunctionProtoType>())
       result = (FT->getRefQualifier() == RQ_LValue);
   } else if (RV.isReflectedDecl()) {
     if (const auto *FD = dyn_cast<FunctionDecl>(RV.getReflectedDecl()))
-      if (auto FT = dyn_cast<FunctionProtoType>(FD->getType()))
+      if (const auto *FT = FD->getType()->getAs<FunctionProtoType>())
         result = (FT->getRefQualifier() == RQ_LValue);
   }
   return SetAndSucceed(Result, makeBool(C, result));
@@ -4251,11 +4255,11 @@ bool is_rvalue_reference_qualified(APValue &Result, ASTContext &C,
 
   bool result = false;
   if (RV.isReflectedType()) {
-    if (auto FT = dyn_cast<FunctionProtoType>(RV.getReflectedType()))
+    if (const auto *FT = RV.getReflectedType()->getAs<FunctionProtoType>())
       result = (FT->getRefQualifier() == RQ_RValue);
   } else if (RV.isReflectedDecl()) {
     if (const auto *FD = dyn_cast<FunctionDecl>(RV.getReflectedDecl()))
-      if (auto FT = dyn_cast<FunctionProtoType>(FD->getType()))
+      if (const auto *FT = FD->getType()->getAs<FunctionProtoType>())
         result = (FT->getRefQualifier() == RQ_RValue);
   }
   return SetAndSucceed(Result, makeBool(C, result));
@@ -6249,7 +6253,7 @@ bool get_ith_parameter_of(APValue &Result, ASTContext &C, MetaActions &Meta,
 
   switch (RV.getReflectionKind()) {
   case ReflectionKind::Type: {
-    if (auto FT = dyn_cast<FunctionProtoType>(RV.getReflectedType())) {
+    if (const auto *FT = RV.getReflectedType()->getAs<FunctionProtoType>()) {
       unsigned numParams = FT->getNumParams();
       if (idx >= numParams)
         return SetAndSucceed(Result, Sentinel);
@@ -6314,7 +6318,7 @@ bool has_ellipsis_parameter(APValue &Result, ASTContext &C, MetaActions &Meta,
     return Diagnoser(Range.getBegin(), diag::metafn_cannot_query_property)
       << 5 << DescriptionOf(RV) << Range;
   case ReflectionKind::Type:
-    if (auto *FPT = dyn_cast<FunctionProtoType>(RV.getReflectedType())) {
+    if (const auto *FPT = RV.getReflectedType()->getAs<FunctionProtoType>()) {
       bool HasEllipsis = FPT->isVariadic();
       return SetAndSucceed(Result, makeBool(C, HasEllipsis));
     }
@@ -6413,7 +6417,7 @@ bool return_type_of(APValue &Result, ASTContext &C, MetaActions &Meta,
 
   switch (RV.getReflectionKind()) {
   case ReflectionKind::Type: {
-    if (auto *FPT = dyn_cast<FunctionProtoType>(RV.getReflectedType())) {
+    if (const auto *FPT = RV.getReflectedType()->getAs<FunctionProtoType>()) {
       QualType QT =
           desugarType(FPT->getReturnType(), /*UnwrapAliases=*/ true,
                       /*DropCV=*/false, /*DropRefs=*/false);

--- a/libcxx/test/std/experimental/reflection/attributed-function-type-queries.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/attributed-function-type-queries.pass.cpp
@@ -1,0 +1,95 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright 2024 Bloomberg Finance L.P.
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03 || c++11 || c++14 || c++17 || c++20
+// ADDITIONAL_COMPILE_FLAGS: -freflection-latest
+// ADDITIONAL_COMPILE_FLAGS: -fentity-proxy-reflection
+
+// <experimental/reflection>
+//
+// [reflection]
+//
+// Regression test: an attribute on a function declarator (e.g.
+// [[clang::lifetimebound]] on the implicit object parameter -- Abseil applies
+// it to every accessor via ABSL_ATTRIBUTE_LIFETIME_BOUND) wraps the
+// declaration's FunctionProtoType in AttributedType sugar. Metafunctions that
+// reached the FunctionProtoType with a sugar-blind dyn_cast misbehaved on such
+// functions: is_const / is_volatile / is_lvalue_reference_qualified /
+// is_rvalue_reference_qualified silently answered false, and return_type_of /
+// parameters_of / has_ellipsis_parameter on the function's TYPE rejected it as
+// not-a-function-type. They now desugar via getAs<FunctionProtoType>, like
+// is_noexcept always did.
+
+#include <meta>
+
+#include <string_view>
+
+constexpr auto unchecked = std::meta::access_context::unchecked();
+
+consteval std::meta::info member_named(std::meta::info cls,
+                                       std::string_view name) {
+  for (auto m : members_of(cls, unchecked))
+    if (has_identifier(m) && identifier_of(m) == name)
+      return m;
+  return {};
+}
+
+struct W {
+  const int& cl() const & [[clang::lifetimebound]] { return v; }
+  int& l() & [[clang::lifetimebound]] { return v; }
+  const int&& cr() const && [[clang::lifetimebound]] {
+    return static_cast<const int&&>(v);
+  }
+  int&& r() && [[clang::lifetimebound]] { return static_cast<int&&>(v); }
+  const volatile int& cv() const volatile [[clang::lifetimebound]] {
+    return v;
+  }
+  int v;
+};
+
+// Qualifier predicates on the declarations themselves.
+static_assert(is_const(member_named(^^W, "cl")));
+static_assert(is_lvalue_reference_qualified(member_named(^^W, "cl")));
+static_assert(!is_rvalue_reference_qualified(member_named(^^W, "cl")));
+static_assert(!is_const(member_named(^^W, "l")));
+static_assert(is_lvalue_reference_qualified(member_named(^^W, "l")));
+static_assert(is_const(member_named(^^W, "cr")));
+static_assert(is_rvalue_reference_qualified(member_named(^^W, "cr")));
+static_assert(!is_const(member_named(^^W, "r")));
+static_assert(is_rvalue_reference_qualified(member_named(^^W, "r")));
+static_assert(!is_lvalue_reference_qualified(member_named(^^W, "r")));
+static_assert(is_const(member_named(^^W, "cv")));
+static_assert(is_volatile(member_named(^^W, "cv")));
+
+// The same queries through the function's TYPE (which carries the sugar),
+// plus the type-introspection metafunctions that rejected it outright.
+static_assert(is_const(type_of(member_named(^^W, "cl"))));
+static_assert(is_lvalue_reference_qualified(type_of(member_named(^^W, "cl"))));
+static_assert(is_rvalue_reference_qualified(type_of(member_named(^^W, "r"))));
+static_assert(is_volatile(type_of(member_named(^^W, "cv"))));
+static_assert(return_type_of(type_of(member_named(^^W, "l"))) == ^^int&);
+static_assert(parameters_of(type_of(member_named(^^W, "l"))).size() == 0);
+static_assert(!has_ellipsis_parameter(type_of(member_named(^^W, "l"))));
+
+// And through an entity proxy's underlying entity (the shape that exposed
+// this in the field: absl::StatusOr<int>'s re-exported accessors).
+struct D : private W {
+  using W::cl;
+  using W::r;
+};
+
+static_assert(is_const(underlying_entity_of(member_named(^^D, "cl"))));
+static_assert(
+    is_lvalue_reference_qualified(underlying_entity_of(member_named(^^D, "cl"))));
+static_assert(
+    is_rvalue_reference_qualified(underlying_entity_of(member_named(^^D, "r"))));
+static_assert(!is_const(underlying_entity_of(member_named(^^D, "r"))));
+
+int main() { return 0; }


### PR DESCRIPTION
Fixes #292.

## Problem

An attribute on a function declarator — e.g. `[[clang::lifetimebound]]` on the implicit object parameter, which Abseil applies to every accessor via `ABSL_ATTRIBUTE_LIFETIME_BOUND` — wraps the declaration's `FunctionProtoType` in `AttributedType` sugar. Seven sites in `ExprConstantMeta.cpp` reached the `FunctionProtoType` with a sugar-blind `dyn_cast` and misbehaved on any such function: `is_const` / `is_volatile` / `is_lvalue_reference_qualified` / `is_rvalue_reference_qualified` silently answered false, and `return_type_of` / `parameters_of` (`get_ith_parameter_of`) / `has_ellipsis_parameter` rejected the function's TYPE as not-a-function-type. The wrong answers are silent — `is_function` still answers true (it checks the declaration kind), so dispatching code misclassifies cv/ref-qualified accessors with no diagnostic anywhere (see #292 for the self-contained reproducer; field shape: all four of `absl::StatusOr<int>::value()`'s overloads reported unqualified).

## Fix

- **`clang/lib/AST/ExprConstantMeta.cpp`** — desugar via `getAs<FunctionProtoType>` at each site (`isConstQualifiedType`, `isVolatileQualifiedType`, both arms of each ref-qualifier predicate, `get_ith_parameter_of`, `has_ellipsis_parameter`, `return_type_of`), exactly as `isFunctionOrMethodNoexcept` (`is_noexcept`) always did. `getAs` returns null for genuine non-function types, so behavior for every other reflection kind is unchanged.

## Test

- `libcxx/test/std/experimental/reflection/attributed-function-type-queries.pass.cpp` (new): qualifier predicates on lifetimebound declarations across the cv/ref matrix (`const&`, `&`, `const&&`, `&&`, `const volatile`), the same queries plus `return_type_of`/`parameters_of`/`has_ellipsis_parameter` through the (attributed) function type, and the predicates through entity-proxy underlying entities (the field shape that exposed this; that part uses `-fentity-proxy-reflection`).

## Validation

- Base: `837da39eb88c` (current `p2996` tip; applies cleanly).
- Without the fix: the six qualifier `static_assert`s in the reproducer fail; the three type queries fail with "static assertion expression is not an integral constant expression" / "cannot introspect the parameters of a non-function type"; the new test reports 15 failures. Removing the attribute (the control) makes everything pass — confirming only sugar-carrying functions were affected.
- With the fix: reproducer and new test compile and run clean.
- `clang/test/Reflection`: 15/16 both at base and with the fix — identical results; the one failure (`splice-exprs.cpp`) is pre-existing at base and unrelated.
- Downstream soak (reflection-driven nanobind binding generator): 50-test binder suite with modules recompiled, plus real-library corpus runs including `absl::StatusOr<int>` — whose `value()` overload qualifiers now all report correctly — and nlohmann/json, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
