### PR TITLE
[clang][reflection] Report substitution failure instead of crashing when substitution forms an invalid type in the declaration

### DIFF
--- a/clang/include/clang/AST/MetaActions.h
+++ b/clang/include/clang/AST/MetaActions.h
@@ -79,17 +79,25 @@ public:
                             SourceLocation InstantiateLoc) = 0;
 
   // Returns the specialization 'TD<TArgs...>'. The template arguments are
-  // assumed to be valid for the specialization, as a precondition.
+  // assumed to be valid for the specialization, as a precondition; substitution
+  // into the DECLARATION can still fail (e.g., the substituted declaration
+  // forms a reference to void inside a template-id), in which case a null
+  // result is returned. When 'SuppressDiagnostics' is true, no diagnostics
+  // leak from a failed substitution.
   virtual QualType Substitute(TypeAliasTemplateDecl *TD,
                               ArrayRef<TemplateArgument> TArgs,
+                              bool SuppressDiagnostics,
                               SourceLocation InstantiateLoc) = 0;
   virtual FunctionDecl *Substitute(FunctionTemplateDecl *TD,
                                    ArrayRef<TemplateArgument> TArgs,
+                                   bool SuppressDiagnostics,
                                    SourceLocation InstantiationLoc) = 0;
   virtual VarDecl *Substitute(VarTemplateDecl *TD,
                               ArrayRef<TemplateArgument> TArgs,
+                              bool SuppressDiagnostics,
                               SourceLocation InstantiateLoc) = 0;
   virtual Expr *Substitute(ConceptDecl *TD, ArrayRef<TemplateArgument> TArgs,
+                           bool SuppressDiagnostics,
                            SourceLocation InstantiateLoc) = 0;
 
                           // ========================

--- a/clang/include/clang/Basic/DiagnosticMetafnKinds.td
+++ b/clang/include/clang/Basic/DiagnosticMetafnKinds.td
@@ -54,6 +54,8 @@ def metafn_cannot_be_arg : Note<
 def metafn_undeduced_placeholder : Note<
   "cannot form a reflection of function %0 whose type %1 contains an undeduced "
   "placeholder">;
+def metafn_substitution_failed : Note<
+  "substitution of the given template arguments into %0 failed">;
 def metafn_cannot_invoke : Note<"cannot invoke %0">;
 def metafn_no_specialization_found : Note<
   "no specialization of the function template %0 matched the provided "

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -3475,18 +3475,27 @@ bool substitute(APValue &Result, ASTContext &C, MetaActions &Meta,
     TArgs.clear();
     expandTemplateArgPacks(ExpandedTArgs, TArgs);
 
-    QualType QT = Meta.Substitute(TATD, TArgs, Range.getBegin());
-    if(QT.isNull()) {
-      // substitution failed after validating arguments
-      return true;
-    }
+    QualType QT = Meta.Substitute(TATD, TArgs, NoDiagnose, Range.getBegin());
+    if (QT.isNull())
+      // Substitution into the declaration failed after the arguments
+      // validated (e.g., formed an invalid type inside a template-id).
+      return NoDiagnose ? ElideDiagnosis() :
+             Diagnoser(Range.getBegin(), diag::metafn_substitution_failed)
+               << TDecl << Range;
     APValue RV = makeReflection(QT);
     //C.recordCachedSubstitution(SubstitutionHash, RV);
     return SetAndSucceed(Result, makeReflection(QT));
   }
   if (auto *FTD = dyn_cast<FunctionTemplateDecl>(TDecl)) {
-    FunctionDecl *Spec = Meta.Substitute(FTD, ExpandedTArgs, Range.getBegin());
-    assert(Spec && "substitution failed after validating arguments?");
+    FunctionDecl *Spec =
+        Meta.Substitute(FTD, ExpandedTArgs, NoDiagnose, Range.getBegin());
+    if (!Spec)
+      // Substitution into the declaration failed after the arguments
+      // validated (e.g., formed a reference to void inside a template-id,
+      // the classic enable_if-style SFINAE failure).
+      return NoDiagnose ? ElideDiagnosis() :
+             Diagnoser(Range.getBegin(), diag::metafn_substitution_failed)
+               << TDecl << Range;
 
     if (Spec->getReturnType()->isUndeducedType())
       return NoDiagnose ? ElideDiagnosis() :
@@ -3501,8 +3510,11 @@ bool substitute(APValue &Result, ASTContext &C, MetaActions &Meta,
     TArgs.clear();
     expandTemplateArgPacks(ExpandedTArgs, TArgs);
 
-    VarDecl *Spec = Meta.Substitute(VTD, TArgs, Range.getBegin());
-    assert(Spec && "substitution failed after validating arguments?");
+    VarDecl *Spec = Meta.Substitute(VTD, TArgs, NoDiagnose, Range.getBegin());
+    if (!Spec)
+      return NoDiagnose ? ElideDiagnosis() :
+             Diagnoser(Range.getBegin(), diag::metafn_substitution_failed)
+               << TDecl << Range;
 
     APValue RV = makeReflection(Spec);
     //C.recordCachedSubstitution(SubstitutionHash, RV);
@@ -3512,8 +3524,11 @@ bool substitute(APValue &Result, ASTContext &C, MetaActions &Meta,
     TArgs.clear();
     expandTemplateArgPacks(ExpandedTArgs, TArgs);
 
-    Expr *Spec = Meta.Substitute(CD, TArgs, Range.getBegin());
-    assert(Spec && "substitution failed after validating arguments?");
+    Expr *Spec = Meta.Substitute(CD, TArgs, NoDiagnose, Range.getBegin());
+    if (!Spec)
+      return NoDiagnose ? ElideDiagnosis() :
+             Diagnoser(Range.getBegin(), diag::metafn_substitution_failed)
+               << TDecl << Range;
 
     APValue SatisfiesConcept;
     if (!Evaluator(SatisfiesConcept, Spec, true))

--- a/clang/lib/Sema/SemaReflect.cpp
+++ b/clang/lib/Sema/SemaReflect.cpp
@@ -366,9 +366,14 @@ public:
 
   QualType Substitute(TypeAliasTemplateDecl *TD,
                       ArrayRef<TemplateArgument> TArgs,
+                      bool SuppressDiagnostics,
                       SourceLocation InstantiateLoc) override {
     TemplateArgumentListInfo TAListInfo;
     populateTemplateArgumentListInfo(TAListInfo, TArgs, InstantiateLoc);
+
+    std::optional<Sema::SuppressDiagnosticsRAII> NoDiagnostics;
+    if (SuppressDiagnostics)
+      NoDiagnostics.emplace(S);
 
     // TODO(P2996): Calling 'substitute' should substitute without
     // instantiation. Should a lighter weight call be used?
@@ -378,15 +383,27 @@ public:
 
   FunctionDecl *Substitute(FunctionTemplateDecl *TD,
                            ArrayRef<TemplateArgument> TArgs,
+                           bool SuppressDiagnostics,
                            SourceLocation InstantiateLoc) override {
     void *InsertPos;
     FunctionDecl *Spec = TD->findSpecialization(TArgs, InsertPos);
     if (!Spec) {
       auto *TArgsCopy = TemplateArgumentList::CreateCopy(S.Context, TArgs);
 
+      std::optional<Sema::SuppressDiagnosticsRAII> NoDiagnostics;
+      if (SuppressDiagnostics)
+        NoDiagnostics.emplace(S);
+
       // TODO(P2996): Calling 'substitute' should substitute without
       // instantiation. Should a lighter weight call be used?
       Spec = S.InstantiateFunctionDeclaration(TD, TArgsCopy, InstantiateLoc);
+
+      // Substitution into the declaration can fail in the immediate context
+      // even though the arguments themselves validated (e.g., forming a
+      // reference to void inside a template-id); report failure rather than
+      // crashing on the null result.
+      if (!Spec)
+        return nullptr;
 
       // Only instantiate the body if the signature has an undeduced type.
       if (Spec->getType()->isUndeducedType())
@@ -396,12 +413,17 @@ public:
   }
 
   VarDecl *Substitute(VarTemplateDecl *TD, ArrayRef<TemplateArgument> TArgs,
+                      bool SuppressDiagnostics,
                       SourceLocation InstantiateLoc) override {
     void *InsertPos;
     VarDecl *Spec = TD->findSpecialization(TArgs, InsertPos);
     if (!Spec) {
       TemplateArgumentListInfo TAListInfo;
       populateTemplateArgumentListInfo(TAListInfo, TArgs, InstantiateLoc);
+
+      std::optional<Sema::SuppressDiagnosticsRAII> NoDiagnostics;
+      if (SuppressDiagnostics)
+        NoDiagnostics.emplace(S);
 
       DeclResult Result = S.CheckVarTemplateId(TD, InstantiateLoc,
                                                InstantiateLoc, TAListInfo);
@@ -416,12 +438,17 @@ public:
   }
 
   Expr *Substitute(ConceptDecl *TD, ArrayRef<TemplateArgument> TArgs,
+                   bool SuppressDiagnostics,
                    SourceLocation InstantiateLoc) override {
     TemplateArgumentListInfo TAListInfo;
     populateTemplateArgumentListInfo(TAListInfo, TArgs, InstantiateLoc);
 
     CXXScopeSpec SS;
     DeclarationNameInfo DNI(TD->getDeclName(), InstantiateLoc);
+
+    std::optional<Sema::SuppressDiagnosticsRAII> NoDiagnostics;
+    if (SuppressDiagnostics)
+      NoDiagnostics.emplace(S);
 
     ExprResult Result = S.CheckConceptTemplateId(SS, InstantiateLoc, DNI, TD,
                                                  TD, &TAListInfo);

--- a/libcxx/test/std/experimental/reflection/can-substitute-invalid-type-formation.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/can-substitute-invalid-type-formation.pass.cpp
@@ -1,0 +1,94 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright 2024 Bloomberg Finance L.P.
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03 || c++11 || c++14 || c++17 || c++20
+// ADDITIONAL_COMPILE_FLAGS: -freflection-latest
+
+// <experimental/reflection>
+//
+// [reflection]
+//
+// Regression test: can_substitute must report substitution failure -- not
+// crash -- when substituting the arguments into the DECLARATION forms an
+// invalid type inside a template-id (e.g. a reference to void, the canonical
+// enable_if-era immediate-context SFINAE failure). The arguments themselves
+// validate against the template-parameter list (void is a fine argument for
+// `class OT`), so the failure surfaces only while instantiating the
+// declaration. Previously:
+//   * function templates: clang SIGSEGV'd (null Spec dereferenced in
+//     MetaActionsImpl::Substitute);
+//   * alias templates: a hard error leaked out of CheckTemplateIdType and the
+//     evaluation was non-constant;
+//   * variable templates: an assertion failure ("substitution failed after
+//     validating arguments?").
+// The field shape is tl::expected<void, E>: its swap member template's
+// DEFAULTED parameter picks up the enclosing specialization's void argument,
+// so merely probing members with can_substitute({}) crashed the compiler.
+
+#include <meta>
+
+#include <vector>
+
+namespace meta = std::meta;
+constexpr auto ctx = meta::access_context::unchecked();
+
+template <class T> struct trait { using type = void; };
+
+// Substituting OT=void must form trait<void&>: an invalid type in the
+// immediate context => substitution failure, not a crash.
+template <class OT> typename trait<OT&>::type f() {}
+
+// The tl::expected<void, E>::swap field shape: a member template whose
+// DEFAULTED parameter picks up the enclosing specialization's argument.
+template <class T> struct Exp {
+  template <class OT = T>
+  typename trait<OT&>::type swap(Exp&) {}
+};
+
+// Same-family siblings hardened in the same change.
+template <class T> using Ref = typename trait<T&>::type;    // alias template
+template <class T> typename trait<T&>::type* vt = nullptr;  // variable template
+
+// Probes every function template among cls's members with a zero-argument
+// substitution (the defaulted parameter supplies the enclosing argument);
+// returns substitutable-count * 100 + probed-count.
+consteval int probe_member_templates(meta::info cls) {
+  int substitutable = 0, probed = 0;
+  for (auto mem : meta::members_of(cls, ctx))
+    if (meta::is_function_template(mem)) {
+      ++probed;
+      if (meta::can_substitute(mem, std::vector<meta::info>{}))
+        ++substitutable;
+    }
+  return substitutable * 100 + probed;
+}
+
+// Controls: non-void substitution succeeds, and substitute() agrees.
+static_assert(meta::can_substitute(^^f, {^^int}));
+static_assert(meta::substitute(^^f, {^^int}) != meta::info{});
+
+// Crash shape #1: explicit void argument on a free function template.
+static_assert(!meta::can_substitute(^^f, {^^void}));
+
+// Crash shape #2: the defaulted-parameter member template found via the
+// members_of walk -- Exp<void>::swap must report not-substitutable (0 of 1)...
+static_assert(probe_member_templates(^^Exp<void>) == 1);
+// ...while the Exp<int> control substitutes (1 of 1).
+static_assert(probe_member_templates(^^Exp<int>) == 101);
+
+// Same-family: alias template (previously a leaked hard error).
+static_assert(!meta::can_substitute(^^Ref, {^^void}));
+static_assert(meta::can_substitute(^^Ref, {^^int}));
+
+// Same-family: variable template (previously an assertion failure).
+static_assert(!meta::can_substitute(^^vt, {^^void}));
+static_assert(meta::can_substitute(^^vt, {^^int}));
+
+int main() { return 0; }

--- a/libcxx/test/std/experimental/reflection/substitute.verify.cpp
+++ b/libcxx/test/std/experimental/reflection/substitute.verify.cpp
@@ -500,4 +500,22 @@ constexpr auto r2 = substitute(^^fn2, {^^int});
   // expected-note@-1 {{requested here}}
 }  // namespace wording_example
 
+                       // ======================
+                       // invalid_type_formation
+                       // ======================
+
+// Substitution that forms an invalid type inside a template-id in the
+// DECLARATION (reference to void) fails after the arguments themselves
+// validated: can_substitute answers false and substitute diagnoses the
+// failure (previously a clang SIGSEGV).
+namespace invalid_type_formation {
+template <class T> struct trait { using type = void; };
+template <class OT> typename trait<OT&>::type fn();
+
+static_assert(!can_substitute(^^fn, {^^void}));
+constexpr auto r = substitute(^^fn, {^^void});
+  // expected-error@-1 {{must be initialized by a constant expression}} \
+  // expected-note@-1 {{substitution of the given template arguments into 'fn' failed}}
+}  // namespace invalid_type_formation
+
 int main() { }


### PR DESCRIPTION
Fixes #294.

## Problem

`can_substitute` — the SFINAE probe that is supposed to answer `false` for failing substitutions — crashed the frontend when substituting the (individually valid) arguments into the *declaration* formed an invalid type inside a template-id, e.g. a reference to void: the classic `enable_if`-era immediate-context failure (see #294 for self-contained reproducers and crash signatures). `CheckTemplateArgumentList` succeeds (void is a fine argument for `class OT`), then per template kind: function templates **SIGSEGV** (`InstantiateFunctionDeclaration` runs in a SFINAE context and returns null; `MetaActionsImpl::Substitute` dereferenced it), alias templates **leak a hard error** out of `CheckTemplateIdType` and go non-constant, variable templates **trip the post-`Substitute` assert** ("substitution failed after validating arguments?"). The field shape is `tl::expected<void, E>`'s `swap` member template, whose defaulted parameter picks up the enclosing specialization's `void` argument — merely probing members with `can_substitute({})` crashed the compiler.

## Fix

- **`clang/include/clang/AST/MetaActions.h`** — the four `Substitute` overloads gain a `bool SuppressDiagnostics` parameter (matching the existing `CheckTemplateArgumentList` contract) and a documented null-on-failure contract.
- **`clang/lib/Sema/SemaReflect.cpp`** — each override wraps its Sema call in `Sema::SuppressDiagnosticsRAII` when requested; the `FunctionTemplateDecl` override null-checks `InstantiateFunctionDeclaration`'s result before the `Spec->getType()` dereference (the SEGV); the alias/var/concept overrides already produce null on failure and are now diagnostically clean.
- **`clang/lib/AST/ExprConstantMeta.cpp`** — `substitute` replaces the post-`Substitute` asserts / ignored failures with the `NoDiagnose` pattern for all four kinds: `can_substitute` → `false` (null reflection via `ElideDiagnosis`), `substitute` → non-constant with the new `metafn_substitution_failed` note — the same shape as the existing `metafn_undeduced_placeholder` path.
- **`clang/include/clang/Basic/DiagnosticMetafnKinds.td`** — the new note.

## Test

- `libcxx/test/std/experimental/reflection/can-substitute-invalid-type-formation.pass.cpp` (new): the free-function-template `{^^void}` shape, the defaulted-parameter member template probed through a `members_of` walk (`Exp<void>` vs the `Exp<int>` control), and the alias/variable-template siblings — each previously a crash/leak/assert, now reporting failure; positive controls assert non-void substitutions still succeed.
- `substitute.verify.cpp` (extended): pins the diagnosing behavior — `substitute(^^fn, {^^void})` is non-constant with the note `substitution of the given template arguments into 'fn' failed`.

## Validation

- Base: `837da39eb88c` (current `p2996` tip; applies cleanly, builds standalone).
- Without the fix: the reproducers in #294 SIGSEGV (function), hard-error (alias), assert (variable); the new test crashes the compiler.
- With the fix: reproducers and the new tests compile and run clean.
- `clang/test/Reflection`: 16/16 with the fix on this machine — identical to base.
- Downstream soak (reflection-driven nanobind binding generator): 53-test binder suite green; real-library corpus runs including TartanLlama/expected v1.3.1 with `tl::expected<void, std::string>` IN the bind set — the binder's `can_substitute({})` probes on `swap<OT=void>`/`value<U=void>` now report not-substitutable and the members are gracefully skipped, with the full differential suite passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
