### PR TITLE
[clang][reflection] Complete reflected specializations with implicit-instantiation semantics

### DIFF
--- a/clang/lib/Sema/SemaReflect.cpp
+++ b/clang/lib/Sema/SemaReflect.cpp
@@ -287,13 +287,37 @@ public:
                                CTSD->getTemplateArgs().asArray()))
         return true;
 
+      // Complete the specialization with ordinary implicit-instantiation
+      // semantics, mirroring Sema::RequireCompleteTypeImpl: member
+      // DECLARATIONS are instantiated, member DEFINITIONS remain subject to
+      // lazy, odr-use-driven instantiation. Completing with
+      // TSK_ExplicitInstantiationDefinition and instantiating every member
+      // definition wrong-rejected specializations whose never-odr-used member
+      // bodies are ill-formed (the "specialized storage base" idiom, e.g.
+      // tl::expected<void, E>), and made the result depend on whether earlier
+      // code happened to have instantiated the class already.
       if (S.InstantiateClassTemplateSpecialization(
-              Range.getBegin(), CTSD, TSK_ExplicitInstantiationDefinition, false,
-              false))
+              Range.getBegin(), CTSD, TSK_ImplicitInstantiation,
+              /*Complain=*/false, CTSD->hasStrictPackMatch()))
         return false;
-
-      S.InstantiateClassTemplateSpecializationMembers(
-              Range.getBegin(), CTSD, TSK_ExplicitInstantiationDefinition);
+    } else if (auto *RD = dyn_cast<CXXRecordDecl>(D);
+               RD && !RD->isCompleteDefinition() && !RD->isBeingDefined() &&
+               !RD->isDependentContext() &&
+               RD->getInstantiatedFromMemberClass()) {
+      // A member class of an instantiated class template: complete it the way
+      // Sema::RequireCompleteTypeImpl would. (The eager path above used to
+      // define nested classes as a side effect of instantiating every member
+      // of the enclosing specialization; completing on demand keeps them
+      // reachable for reflection queries.)
+      MemberSpecializationInfo *MSI = RD->getMemberSpecializationInfo();
+      assert(MSI && "missing member specialization information");
+      if (MSI->getTemplateSpecializationKind() != TSK_ExplicitSpecialization &&
+          S.InstantiateClass(Range.getBegin(), RD,
+                             RD->getInstantiatedFromMemberClass(),
+                             S.getTemplateInstantiationArgs(RD),
+                             TSK_ImplicitInstantiation,
+                             /*Complain=*/false))
+        return false;
     } else if (auto *VTSD = dyn_cast<VarTemplateSpecializationDecl>(D);
         VTSD && !VTSD->isCompleteDefinition()) {
       if (!validateConstraints(VTSD->getSpecializedTemplate(),

--- a/libcxx/test/std/experimental/reflection/members-of-lazily-ill-formed-bodies.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/members-of-lazily-ill-formed-bodies.pass.cpp
@@ -1,0 +1,97 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright 2024 Bloomberg Finance L.P.
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03 || c++11 || c++14 || c++17 || c++20
+// ADDITIONAL_COMPILE_FLAGS: -freflection-latest
+
+// <experimental/reflection>
+//
+// [reflection]
+//
+// Regression test: a type-completing metafunction (members_of & co.), when it
+// is the FIRST thing to instantiate a class template specialization, must
+// complete it with ordinary implicit-instantiation semantics -- member
+// DECLARATIONS instantiated, member DEFINITIONS not. EnsureInstantiated used
+// TSK_ExplicitInstantiationDefinition plus
+// InstantiateClassTemplateSpecializationMembers, eagerly instantiating every
+// member body; a specialization whose never-odr-used member bodies are
+// ill-formed (the "specialized storage base" idiom, e.g. tl::expected<void, E>
+// -- valid C++ as long as those members are never odr-used) was
+// wrong-rejected, but ONLY when reflection got to the type before ordinary
+// use did (order-dependent enumeration).
+
+#include <meta>
+
+#include <cassert>
+#include <string_view>
+
+namespace meta = std::meta;
+constexpr auto ctx = meta::access_context::unchecked();
+
+template <class T> struct storage { T m_val; };
+template <> struct storage<void> { char m_dummy; };
+
+// Each probe below must be the FIRST instantiation trigger for its
+// specialization, so each metafunction gets a distinct template.
+template <class T> struct Exp1 : private storage<T> {
+  T *valptr() { return &this->m_val; }  // body ill-formed for T = void
+  bool has_value() const { return true; }
+};
+template <class T> struct Exp2 : private storage<T> {
+  T *valptr() { return &this->m_val; }
+  bool has_value() const { return true; }
+};
+template <class T> struct Exp3 : private storage<T> {
+  T *valptr() { return &this->m_val; }
+  bool has_value() const { return true; }
+};
+template <class T> struct Exp4 : private storage<T> {
+  T *valptr() { return &this->m_val; }
+  bool has_value() const { return true; }
+};
+template <class T> struct Exp5 : private storage<T> {
+  T *valptr() { return &this->m_val; }
+  bool has_value() const { return true; }
+};
+
+consteval int count_named(meta::info cls, std::string_view name) {
+  int n = 0;
+  for (auto m : meta::members_of(cls, ctx))
+    if (meta::has_identifier(m) && meta::identifier_of(m) == name)
+      ++n;
+  return n;
+}
+
+// members_of as the first instantiation trigger: must compile and enumerate
+// the member declarations. Control: the void specialization enumerates the
+// same surface as the well-formed-body int specialization.
+static_assert(meta::members_of(^^Exp1<void>, ctx).size() ==
+              meta::members_of(^^Exp1<int>, ctx).size());
+static_assert(count_named(^^Exp1<void>, "valptr") == 1);
+static_assert(count_named(^^Exp1<void>, "has_value") == 1);
+
+// Order-independence: ordinary use first, then the identical enumeration.
+Exp2<void> preinstantiated;
+static_assert(meta::members_of(^^Exp2<void>, ctx).size() ==
+              meta::members_of(^^Exp1<void>, ctx).size());
+
+// Other completing metafunctions as first triggers (same completion funnel).
+static_assert(meta::nonstatic_data_members_of(^^Exp3<void>, ctx).size() == 0);
+static_assert(meta::bases_of(^^Exp3<void>, ctx).size() == 1);
+static_assert(meta::is_complete_type(^^Exp4<void>));
+static_assert(meta::size_of(^^Exp5<void>) == 1);  // just storage<void>::m_dummy
+
+int main() {
+  // Lazy semantics still instantiate bodies that ARE odr-used.
+  Exp1<int> e;
+  assert(e.valptr() != nullptr);
+  assert(e.has_value());
+  return 0;
+}


### PR DESCRIPTION
Fixes #296.

## Problem

`SemaMetaActions::EnsureInstantiated` — the single completion funnel for every type-completing metafunction (`members_of`, `bases_of`, `size_of`, `is_complete_type`, ...) — completed class template specializations with `TSK_ExplicitInstantiationDefinition` **plus** `InstantiateClassTemplateSpecializationMembers`, eagerly instantiating every member *definition*. A specialization whose never-odr-used member bodies are ill-formed (the "specialized storage base" idiom — valid C++; `tl::expected<void, E>` is the field shape) was wrong-rejected, **order-dependently**: a preceding ordinary use completed the class lazily first and the identical `members_of` loop then compiled clean (see #296 for the reproducer + `-DPREINSTANTIATE` control). The eager kind also marked the specialization as a user-written explicit instantiation definition — weak-ODR emission of every member in the TU, and collisions with genuine `template struct ...;` declarations.

## Fix

`clang/lib/Sema/SemaReflect.cpp`, `EnsureInstantiated`: mirror `Sema::RequireCompleteTypeImpl` —

- `InstantiateClassTemplateSpecialization(..., TSK_ImplicitInstantiation, /*Complain=*/false, CTSD->hasStrictPackMatch())`;
- drop the `InstantiateClassTemplateSpecializationMembers` sweep entirely (a reflection query needs completeness — layout, bases, declared members — never member bodies);
- add the member-class-of-a-template branch (`InstantiateClass` on `getInstantiatedFromMemberClass`, `TSK_ImplicitInstantiation`) that the eager member sweep used to cover as a side effect, so `members_of(^^Outer<T>::Inner)` keeps working when reflection completes `Inner` on demand.

Body-needing consumers (`extract`, `reflect_invoke`, `substitute` of deduced-return functions) re-enter `EnsureInstantiated` with the specific `FunctionDecl`/`VarDecl`; those branches are untouched, so constant-evaluating a member of an implicitly-instantiated specialization still instantiates its body on demand.

## Test

`libcxx/test/std/experimental/reflection/members-of-lazily-ill-formed-bodies.pass.cpp` (new): the specialized-storage-base idiom with five distinct templates so each metafunction (`members_of`, `nonstatic_data_members_of`, `bases_of`, `is_complete_type`, `size_of`) is the *first* instantiation trigger for its specialization; an order-independence control (ordinary use first → identical enumeration); and a runtime check that odr-used bodies still instantiate lazily.

## Validation

- Base: `837da39eb88c` (current `p2996` tip; applies cleanly, builds standalone).
- Without the fix: the #296 reproducer errors (`no member named 'm_val' in 'Exp<void>'` from inside the `members_of` iteration) and is order-dependent; the new test wrong-rejects.
- With the fix: reproducer clean in both orderings; new test passes.
- `clang/test/Reflection`: 16/16 with the fix on this machine — identical to base. Body-needing suite spot-checks green: `reflect-invoke.pass.cpp`, `to-and-from-values.pass.cpp`, `consteval-reentrant-instantiation.pass.cpp`, `members-and-subobjects.pass.cpp`.
- Downstream soak (reflection-driven nanobind binding generator): 53-test binder suite green; TartanLlama/expected v1.3.1 corpus run with `tl::expected<void, std::string>` in the bind set passes its full differential suite (previously: nine hard errors from tl's implementation details on bare enumeration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
