### PR TITLE
[clang][reflection] Discriminate same-headed member-template reflections of a specialization in NTTP mangling

### DIFF
--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -29,6 +29,7 @@
 #include "clang/AST/ExprObjC.h"
 #include "clang/AST/LocInfoType.h"
 #include "clang/AST/Mangle.h"
+#include "clang/AST/ODRHash.h"
 #include "clang/AST/TypeLoc.h"
 #include "clang/Basic/ABI.h"
 #include "clang/Basic/Module.h"
@@ -5021,8 +5022,29 @@ void CXXNameMangler::mangleReflection(const APValue &R) {
   case ReflectionKind::Template: {
     Out << 't';
 
+    TemplateDecl *TD = R.getReflectedTemplate().getAsTemplateDecl();
     ArrayRef<TemplateArgument> Args;
-    mangleTemplateName(R.getReflectedTemplate().getAsTemplateDecl(), Args);
+    mangleTemplateName(TD, Args);
+    // The name alone identifies class/variable/alias templates, but function
+    // templates OVERLOAD: two same-named siblings (e.g. absl raw_hash_map's
+    // lifetimebound operator[] pair) mangled identically here, so a template
+    // taking the reflection as an NTTP got ONE mangled name for its two
+    // specializations -- CodeGen then silently folds the linkonce_odr
+    // definitions and a single body serves both call sites (the AST-level
+    // specializations are correct and distinct; no diagnostic anywhere). Append a structural
+    // digest of the template head + declaration pattern to discriminate the
+    // overloads. An ODR hash (cross-TU-stable by design; it is how modules
+    // compare decls between TUs) rather than a structural mangling of the
+    // pattern's function type: dependent pattern types from real code embed
+    // parameter-referencing expressions (lifetimebound SFINAE, noexcept(...))
+    // that the mangler cannot encode outside a function-declaration context
+    // (mangleFunctionParam asserts).
+    if (auto *FTD = dyn_cast<FunctionTemplateDecl>(TD)) {
+      ODRHash Hash;
+      Hash.AddTemplateParameterList(FTD->getTemplateParameters());
+      Hash.AddFunctionDecl(FTD->getTemplatedDecl(), /*SkipBody=*/true);
+      Out << '$' << Hash.CalculateHash() << '$';
+    }
     break;
   }
   case ReflectionKind::Namespace: {

--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -5079,7 +5079,23 @@ void CXXNameMangler::mangleReflection(const APValue &R) {
     if (auto *FTD = dyn_cast<FunctionTemplateDecl>(TD)) {
       ODRHash Hash;
       Hash.AddTemplateParameterList(FTD->getTemplateParameters());
-      Hash.AddFunctionDecl(FTD->getTemplatedDecl(), /*SkipBody=*/true);
+      const FunctionDecl *Pattern = FTD->getTemplatedDecl();
+      Hash.AddFunctionDecl(Pattern, /*SkipBody=*/true);
+      // AddFunctionDecl silently NO-OPS for a declaration in "specialization
+      // context" (a member template of a class template specialization, the
+      // common members_of shape), so siblings sharing one template head
+      // hashed identically there -- tl::expected<T,E>'s four value()
+      // overloads (const&/&/const&&/&&, identical heads) all folded. Hash
+      // the pattern's function type (return type, parameter
+      // types, cv-quals) and its ref-qualifier (which even
+      // VisitFunctionProtoType omits) as well; the ODR type hash handles the
+      // dependent pattern types that a structural MANGLING of the type
+      // cannot (see above).
+      Hash.AddQualType(Pattern->getType());
+      if (const auto *FPT = Pattern->getType()->getAs<FunctionProtoType>()) {
+        Hash.AddBoolean(FPT->getRefQualifier() == RQ_LValue);
+        Hash.AddBoolean(FPT->getRefQualifier() == RQ_RValue);
+      }
       Out << '$' << Hash.CalculateHash() << '$';
     }
     break;

--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -5023,6 +5023,43 @@ void CXXNameMangler::mangleReflection(const APValue &R) {
     Out << 't';
 
     TemplateDecl *TD = R.getReflectedTemplate().getAsTemplateDecl();
+
+    // A deduction guide's DeclarationName (CXXDeductionGuideName) has no
+    // <unqualified-name> encoding: mangleTemplateName would reach the
+    // llvm_unreachable in mangleUnqualifiedName. members_of over a
+    // namespace enumerates guides like any other member, and lifting that
+    // list into define_static_array makes each one a reflection template
+    // argument, so they MUST mangle. Encode "dg" + the deduced template's
+    // name + the same '$'-bracketed ODR-hash discriminator used for
+    // overloaded function templates below: every guide for one template
+    // shares a single DeclarationName (and implicit/copy guides can be
+    // enumerated alongside explicit ones once CTAD has been used in the TU),
+    // so the hash of the template head + declaration pattern is what keeps
+    // two different guides for the same template distinct. Cross-TU-stable by
+    // design, preserving legitimate linkonce_odr merging.
+    if (auto *FTD = dyn_cast<FunctionTemplateDecl>(TD)) {
+      if (auto *DG = dyn_cast<CXXDeductionGuideDecl>(FTD->getTemplatedDecl())) {
+        Out << "dg";
+        if (TemplateDecl *Deduced = DG->getDeducedTemplate())
+          mangleTemplateName(Deduced, /*Args=*/{});
+        ODRHash Hash;
+        // The structural hash alone cannot separate an EXPLICIT guide from
+        // the IMPLICIT guide Sema declares for the same-signature
+        // constructor, nor a per-constructor guide from the copy guide when
+        // their signatures coincide (X(X<E>)); fold implicitness and the
+        // deduction-candidate kind in as well -- all of these enumerate
+        // side by side and are distinct reflections.
+        Hash.AddBoolean(DG->isImplicit());
+        DeductionCandidate DCK = DG->getDeductionCandidateKind();
+        Hash.AddBoolean(DCK == DeductionCandidate::Copy);
+        Hash.AddBoolean(DCK == DeductionCandidate::Aggregate);
+        Hash.AddTemplateParameterList(FTD->getTemplateParameters());
+        Hash.AddFunctionDecl(DG, /*SkipBody=*/true);
+        Out << '$' << Hash.CalculateHash() << '$';
+        break;
+      }
+    }
+
     ArrayRef<TemplateArgument> Args;
     mangleTemplateName(TD, Args);
     // The name alone identifies class/variable/alias templates, but function

--- a/libcxx/test/std/experimental/reflection/deduction-guide-reflection-mangling.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/deduction-guide-reflection-mangling.pass.cpp
@@ -1,0 +1,72 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright 2024 Bloomberg Finance L.P.
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03 || c++11 || c++14 || c++17 || c++20
+// ADDITIONAL_COMPILE_FLAGS: -freflection-latest
+
+// <experimental/reflection>
+//
+// [reflection]
+//
+// Regression test: a reflection of a DEDUCTION GUIDE used as a template
+// argument (a define_static_array element / reflection NTTP) must mangle
+// rather than hitting mangleUnqualifiedName's
+//   llvm_unreachable("Can't mangle a deduction guide name!")
+// (a CXXDeductionGuideName has no <unqualified-name> encoding), and two
+// different guides for the same template must mangle DISTINCTLY -- they share
+// one DeclarationName, so a name-only encoding would fold their
+// specializations at codegen (the same silent failure mode as overloaded
+// function templates, different declaration-name kind). members_of over a namespace enumerates guides like
+// any other member, so any namespace-walking reflection consumer that lifts
+// the member list into static storage hits this. -fsyntax-only does NOT
+// reproduce; the assertions below require codegen and a runtime observation.
+
+#include <meta>
+
+#include <cassert>
+
+namespace demo {
+template <class E> struct unexpected { unexpected(E); };
+template <class E> unexpected(E)  -> unexpected<E>;    // guide #1
+template <class E> unexpected(E*) -> unexpected<E*>;   // guide #2 (same DeclarationName)
+}  // namespace demo
+
+template <std::meta::info R> int probe() { return 1; }
+
+int main() {
+  // The lift itself is the ICE shape: the array backing define_static_array
+  // has every element reflection mangled into its linkage name. Taking
+  // &probe<m> additionally pins each guide reflection as a function-template
+  // NTTP, whose mangled names must be pairwise distinct. The enumeration
+  // contains FOUR guides: the two explicit ones plus the two Sema-declared
+  // implicit ones (the per-constructor guide -- whose signature is
+  // structurally IDENTICAL to explicit guide #1 -- and the copy guide), so
+  // distinctness needs more than a structural hash of the declaration.
+  int (*addrs[8])() = {};
+  int n = 0;
+  template for (constexpr auto m : std::define_static_array(
+      std::meta::members_of(^^demo, std::meta::access_context::unchecked()))) {
+    if constexpr (std::meta::is_function_template(m)) {  // only the guides
+      addrs[n++] = &probe<m>;
+    }
+  }
+  assert(n == 4);
+  for (int i = 0; i < n; ++i) {
+    assert(addrs[i]() == 1);
+    // Distinct manglings: without the per-guide discriminator the
+    // linkonce_odr specializations silently fold into one symbol.
+    for (int j = i + 1; j < n; ++j)
+      assert(addrs[i] != addrs[j]);
+    // A reflection of a guide stays distinct from a reflection of the
+    // deduced class template itself.
+    assert((void *)&probe<^^demo::unexpected> != (void *)addrs[i]);
+  }
+  return 0;
+}

--- a/libcxx/test/std/experimental/reflection/fn-template-nttp-mangling-spec-context.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/fn-template-nttp-mangling-spec-context.pass.cpp
@@ -1,0 +1,101 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright 2024 Bloomberg Finance L.P.
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03 || c++11 || c++14 || c++17 || c++20
+// ADDITIONAL_COMPILE_FLAGS: -freflection-latest
+
+// <experimental/reflection>
+//
+// [reflection]
+//
+// Regression test: reflections of same-named member function templates of a
+// CLASS TEMPLATE SPECIALIZATION used as non-type template arguments must
+// mangle distinctly even when the siblings share an identical template head.
+// The NTTP discriminator introduced for overloaded function templates hashed
+// the template head plus the declaration via ODRHash::AddFunctionDecl -- but
+// AddFunctionDecl silently NO-OPS for any declaration in "specialization
+// context" (a member of a ClassTemplateSpecializationDecl, the common
+// members_of shape), so an overload set like tl::expected<T,E>'s four value()
+// member templates (const& / & / const&& / &&, identical heads) hashed
+// identically: CodeGen silently folded the linkonce_odr specializations of a
+// dispatcher taking the reflection as an NTTP, and one body served all four
+// call sites. The AST-level specializations are correct, so only a RUNTIME
+// observation catches this (same silent-fold mode as the overloaded
+// function-template discriminator's original motivation).
+
+#include <meta>
+
+#include <cassert>
+#include <string_view>
+
+namespace meta = std::meta;
+constexpr auto ctx = meta::access_context::unchecked();
+
+template <class T> struct trait { static constexpr bool value = true; };
+
+// The tl::expected<T,E>::value() field shape: four same-named member function
+// templates with IDENTICAL template heads, differing only in cv/ref qualifiers
+// and (correspondingly) return type.
+template <class T> struct Exp {
+  template <class U = T, bool = trait<U>::value>
+  const U &value() const & { return v; }
+  template <class U = T, bool = trait<U>::value>
+  U &value() & { return v; }
+  template <class U = T, bool = trait<U>::value>
+  const U &&value() const && { return static_cast<const U &&>(v); }
+  template <class U = T, bool = trait<U>::value>
+  U &&value() && { return static_cast<U &&>(v); }
+  T v;
+};
+
+// Two same-headed siblings differing ONLY in ref-qualifier (the return types
+// coincide): the ref-qualifier is not part of what VisitFunctionProtoType
+// hashes, so it needs its own discrimination.
+template <class T> struct RQ {
+  template <class U = T> int get() & { return 1; }
+  template <class U = T> int get() && { return 2; }
+};
+
+template <meta::info R> int probe() { return 1; }
+
+int main() {
+  // All four value() siblings of a specialization must instantiate probe<m>
+  // DISTINCTLY (pre-fix: one mangled name, "definition with same mangled
+  // name" at best, a silent linkonce_odr fold at worst).
+  int (*addrs[8])() = {};
+  int n = 0;
+  template for (constexpr auto m : std::define_static_array(
+      meta::members_of(^^Exp<int>, ctx))) {
+    if constexpr (meta::is_function_template(m) && meta::has_identifier(m)) {
+      if constexpr (meta::identifier_of(m) == std::string_view("value")) {
+        addrs[n++] = &probe<m>;
+      }
+    }
+  }
+  assert(n == 4);
+  for (int i = 0; i < n; ++i)
+    for (int j = i + 1; j < n; ++j)
+      assert(addrs[i] != addrs[j]);
+
+  // Ref-qualifier-only siblings stay distinct too.
+  int (*raddrs[8])() = {};
+  int rn = 0;
+  template for (constexpr auto m : std::define_static_array(
+      meta::members_of(^^RQ<int>, ctx))) {
+    if constexpr (meta::is_function_template(m) && meta::has_identifier(m)) {
+      if constexpr (meta::identifier_of(m) == std::string_view("get")) {
+        raddrs[rn++] = &probe<m>;
+      }
+    }
+  }
+  assert(rn == 2);
+  assert(raddrs[0] != raddrs[1]);
+  return 0;
+}

--- a/libcxx/test/std/experimental/reflection/substitute-nested-dependent.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/substitute-nested-dependent.pass.cpp
@@ -1,0 +1,103 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright 2024 Bloomberg Finance L.P.
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03 || c++11 || c++14 || c++17 || c++20
+// ADDITIONAL_COMPILE_FLAGS: -freflection-latest
+
+// <experimental/reflection>
+//
+// [reflection]
+//
+// Regression test: reflections of same-named (overloaded) function templates
+// used as non-type template arguments must produce DISTINCT specializations
+// all the way through codegen. Previously the Itanium mangling for a
+// ReflectionKind::Template encoded only the template's name, so a dispatcher
+// like fn_probe<T, tmpl> below got one mangled name for its two
+// instantiations; CodeGen silently folded the linkonce_odr definitions, and a
+// single body (here: the SFINAE-false pack sibling's) served both call sites.
+// The AST-level specializations were always correct, so only a RUNTIME
+// observation catches this.
+
+#include <meta>
+
+#include <cassert>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+template <bool C> using EnableIf = std::enable_if_t<C, int>;
+template <class K, bool V> inline constexpr bool LTB = !V;
+
+struct B {
+  // Instantiable with zero explicit arguments (every parameter defaulted).
+  template <class K = int, class P = double, int = EnableIf<LTB<K, false>>()>
+  std::string& operator[](K&& k);
+  // SFINAE-false pack sibling: same name, never instantiable.
+  template <class K = int, class P = double, int&..., EnableIf<LTB<K, true>> = 0>
+  std::string& operator[](K&& k);
+};
+
+consteval bool can_sub0(std::meta::info tmpl) {
+  return std::meta::can_substitute(tmpl, std::vector<std::meta::info>{});
+}
+consteval std::meta::info sub0(std::meta::info tmpl) {
+  return std::meta::substitute(tmpl, std::vector<std::meta::info>{});
+}
+consteval int member_index(std::meta::info cls, std::meta::info fn) {
+  int i = 0;
+  for (auto m : std::meta::members_of(cls, std::meta::access_context::unchecked())) {
+    if (m == fn) return i;
+    ++i;
+  }
+  return -1;
+}
+
+// The probe: substitute() two dependent levels deep (called from a `template
+// for` body in fn_driver). Encodes which template it was instantiated for and
+// whether it substituted into its return value.
+template <typename T, std::meta::info tmpl>
+int fn_probe() {
+  if constexpr (can_sub0(tmpl)) {
+    constexpr auto spec = sub0(tmpl);
+    static_assert(std::meta::is_operator_function(spec));
+    static_assert(!std::meta::is_volatile(spec));
+    static_assert(!std::meta::is_rvalue_reference_qualified(spec));
+    return member_index(^^T, tmpl) * 10 + 1;
+  } else {
+    return member_index(^^T, tmpl) * 10;
+  }
+}
+
+template <typename T>
+void fn_driver() {
+  int results[2];
+  int (*addrs[2])();
+  int n = 0;
+  template for (constexpr auto fn : std::define_static_array(
+          std::meta::members_of(^^T, std::meta::access_context::unchecked()))) {
+    if constexpr (std::meta::is_function_template(fn)) {
+      results[n] = fn_probe<T, fn>();
+      addrs[n] = &fn_probe<T, fn>;
+      ++n;
+    }
+  }
+  assert(n == 2);
+  // Distinct specializations: under the mangling collision these were one
+  // folded symbol, so the addresses compared equal and one body ran twice.
+  assert(addrs[0] != addrs[1]);
+  // member#0 substitutes (0 * 10 + 1), the pack sibling does not (1 * 10).
+  assert(results[0] == 1);
+  assert(results[1] == 10);
+}
+
+int main() {
+  fn_driver<B>();
+  return 0;
+}


### PR DESCRIPTION
Fixes #300.

> **Stacked on #287 and the deduction-guide PR (#299)** — the first two commits are theirs (this change amends the same `mangleReflection` hash block); review the last commit only.

## Problem

The NTTP discriminator for overloaded function-template reflections (#286 / #287) hashes the template parameter list plus the declaration pattern via `ODRHash::AddFunctionDecl(pattern, /*SkipBody=*/true)`. But `AddFunctionDecl` **silently no-ops for any declaration in "specialization context"** — its decl-context walk returns on finding a `ClassTemplateSpecializationDecl`. A member template of an instantiated class template — the common `members_of` shape — therefore contributed only its template HEAD to the hash, and same-named siblings with **identical heads** still mangled identically. #287's own field shape (absl `operator[]` + its pack twin) escaped only because those heads differ.

Field shape: `tl::expected<T,E>`'s four `value()` member templates (`const&`/`&`/`const&&`/`&&`, one shared `template <class U = T, enable_if_t<!is_void<U>::value>* = nullptr>` head) — all four reflections got one mangled name, CodeGen silently folded the linkonce_odr dispatcher specializations of a reflection-driven binding generator, and `value()` never bound. Caught by a differential test suite, not a diagnostic; where the TU collides explicitly the symptom is `error: definition with same mangled name ... as another definition` (see #300 for the reproducer).

## Fix

`clang/lib/AST/ItaniumMangle.cpp`, same hash block: additionally hash what `AddFunctionDecl` skips in specialization context —

- the pattern's function type via `ODRHash::AddQualType` (return type, parameter types, cv-quals). The ODR *hash* handles the dependent pattern types that a structural *mangling* of the type cannot (lifetimebound SFINAE, `noexcept(...)` referencing parameters — the original #287 constraint);
- the ref-qualifier, which even `ODRHash`'s `VisitFunctionProtoType` omits — two siblings can differ in nothing else.

## Test

`libcxx/test/std/experimental/reflection/fn-template-nttp-mangling-spec-context.pass.cpp` (new): the four-sibling `value()` shape (identical heads, cv/ref-qualifier + return-type differences) and a ref-qualifier-only pair, each pinned as `&probe<m>` NTTPs from a `members_of` walk over the *specialization* and asserted pairwise distinct at runtime.

## Validation

- Base: the deduction-guide PR's branch tip (itself on #287 on `837da39eb88c`); builds standalone.
- Without the fix: the #300 reproducer fails at `-c` with the duplicate-mangled-name error (clean at `-fsyntax-only`; clean with the same signatures at namespace scope — the no-specialization-context control); the new test fails.
- With the fix: reproducer matrix clean; new test passes; #287's `substitute-nested-dependent.pass.cpp` and the deduction-guide test still pass on the stack tip.
- `clang/test/Reflection`: 16/16 with the fix on this machine — identical to base.
- Downstream soak (reflection-driven nanobind binding generator): 53-test binder suite green; the TartanLlama/expected v1.3.1 corpus run that caught this (its `value()` differential went from `AttributeError` to passing) is green end-to-end, `tl::expected<int,std::string>::value()` bound with all four sibling reflections mangled distinctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
