### PR TITLE
[clang][reflection] Keep namespace member walks clear of out-of-line class-member definitions

### DIFF
--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -1433,6 +1433,18 @@ static bool ensureDeclared(ASTContext &C, QualType QT, SourceLocation SpecLoc) {
 static bool isReflectableDecl(MetaActions &Meta, ASTContext &C, Decl *D) {
   assert(D && "null declaration");
 
+  // An out-of-line definition of a class member sits lexically in a namespace
+  // but belongs semantically to its class (Eigen defines most MatrixBase
+  // members this way, in re-opened namespace blocks). It is a pure
+  // redeclaration: the entity is enumerable through its class, never through
+  // the namespace -- and a reflection of the dependent definition PATTERN
+  // (when the class is a template) breaks downstream metafunctions outright.
+  // The redeclaration check below does not catch it: the definition is the
+  // FIRST declaration in its own lexical context.
+  if (D->getDeclContext() != D->getLexicalDeclContext() &&
+      isa<CXXRecordDecl>(D->getDeclContext()))
+    return false;
+
   if (D != D->getCanonicalDecl()) {
     Decl *First = nullptr;
     for (Decl *I = D->getMostRecentDecl(); I; I = I->getPreviousDecl())
@@ -1494,6 +1506,19 @@ static Decl *findIterableMember(MetaActions &Meta, ASTContext &C, Decl *D,
 
   do {
     DeclContext *DC = D->getDeclContext();  // note: SemanticDC
+
+    // Stepping FROM an out-of-line class-member definition must walk the
+    // lexical (namespace) chain it sits in: its semantic context is the
+    // class, and consulting that would leave the enumerated namespace
+    // entirely (the cross-block hop below can land on such a definition when
+    // it is the first declaration of a re-opened namespace block -- silently
+    // dropping every remaining member). Decls whose semantic context is a
+    // NAMESPACE but whose lexical context differs are NOT rewritten: those
+    // are the legitimate getLastMultDCSemaDecl/getPrevMultDCDeclInSemaContext
+    // chain (e.g. `void ns::f() {}` defined at translation-unit scope).
+    if (DC != D->getLexicalDeclContext() && isa<CXXRecordDecl>(DC) &&
+        D->getLexicalDeclContext()->isFileContext())
+      DC = D->getLexicalDeclContext();
 
     if (D->getLexicalDeclContext() == DC) {
       // Get the next declaration in the DeclContext.

--- a/libcxx/test/std/experimental/reflection/namespace-members-out-of-line-defs.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/namespace-members-out-of-line-defs.pass.cpp
@@ -1,0 +1,114 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright 2024 Bloomberg Finance L.P.
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03 || c++11 || c++14 || c++17 || c++20
+// ADDITIONAL_COMPILE_FLAGS: -freflection-latest
+
+// <experimental/reflection>
+//
+// [reflection]
+//
+// Regression test: an out-of-line definition of a class member at namespace
+// scope is a redeclaration of the CLASS member -- it must never be enumerated
+// as a member of the namespace, and its presence must not derail the
+// namespace walk. Two defects compounded when a RE-OPENED namespace block
+// began with such a definition (Eigen's header layout: EulerAngles.h opens
+// `namespace Eigen` with the MatrixBase<Derived>::canonicalEulerAngles
+// definition):
+//   1. the definition (for a class template, the dependent definition
+//      PATTERN) was yielded as a namespace member -- and reflections of such
+//      patterns break downstream metafunctions;
+//   2. stepping from it walked the CLASS's chain instead of the namespace's,
+//      silently dropping every remaining namespace member (members_of
+//      returned ONE wrong entry for the whole namespace).
+
+#include <experimental/meta>
+
+#include <string_view>
+
+namespace single {
+struct Plain { int f() const; };
+int Plain::f() const { return 1; }            // out-of-line, same block
+template <class T> struct Tmpl { int g() const; };
+template <class T> int Tmpl<T>::g() const { return 2; }
+inline int h() { return 3; }
+}  // namespace single
+
+namespace re {
+template <class T> struct Tmpl { int g() const; };
+inline int h() { return 3; }
+}  // namespace re
+
+namespace re {                                 // re-opened; FIRST decl is the
+template <class T> int Tmpl<T>::g() const {    // out-of-line definition PATTERN
+  return 2;
+}
+inline int k() { return 4; }
+struct Plain { int f() const; };
+}  // namespace re
+
+namespace re {                                 // re-opened again; starts with
+int Plain::f() const { return 1; }             // a NON-template out-of-line def
+inline int m() { return 5; }
+}  // namespace re
+
+consteval bool ns_has_member(std::meta::info ns, std::string_view name) {
+  for (auto m :
+       std::meta::members_of(ns, std::meta::access_context::unchecked()))
+    if (std::meta::has_identifier(m) && std::meta::identifier_of(m) == name)
+      return true;
+  return false;
+}
+
+consteval std::size_t ns_member_count(std::meta::info ns) {
+  std::size_t n = 0;
+  for (auto m :
+       std::meta::members_of(ns, std::meta::access_context::unchecked())) {
+    (void)m;
+    ++n;
+  }
+  return n;
+}
+
+int main() {
+  // Single-block namespace: out-of-line defs interleaved with members.
+  static_assert(ns_has_member(^^single, "Plain"));
+  static_assert(ns_has_member(^^single, "Tmpl"));
+  static_assert(ns_has_member(^^single, "h"));
+  static_assert(!ns_has_member(^^single, "f"));
+  static_assert(!ns_has_member(^^single, "g"));
+  static_assert(ns_member_count(^^single) == 3);
+
+  // Re-opened blocks BEGINNING with out-of-line definitions: every real
+  // member across all blocks must survive, no definition may leak in.
+  static_assert(ns_has_member(^^re, "Tmpl"));
+  static_assert(ns_has_member(^^re, "Plain"));
+  static_assert(ns_has_member(^^re, "h"));
+  static_assert(ns_has_member(^^re, "k"));
+  static_assert(ns_has_member(^^re, "m"));
+  static_assert(!ns_has_member(^^re, "g"));
+  static_assert(!ns_has_member(^^re, "f"));
+  static_assert(ns_member_count(^^re) == 5);
+
+  // The class member itself is still enumerable through its class, and the
+  // namespace-scope definition did not duplicate it.
+  static_assert(ns_member_count(^^re) == 5);
+  consteval {
+    std::size_t fs = 0;
+    for (auto m : std::meta::members_of(
+             ^^re::Plain, std::meta::access_context::unchecked()))
+      if (std::meta::has_identifier(m) && std::meta::identifier_of(m) == "f")
+        ++fs;
+    if (fs != 1)
+      __builtin_abort();
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Fixes #303.

Two complementary changes to the namespace member walk in `ExprConstantMeta.cpp`:

- `isReflectableDecl`: reject any decl whose semantic `DeclContext` is a `CXXRecordDecl` while its lexical context differs. An out-of-line definition of a class member is a pure redeclaration — the entity is enumerable through its class, never through the namespace it is lexically written in — and its redeclaration filter used to pass it (the definition is the *first* declaration in its own lexical context), yielding (for class templates) a dependent definition PATTERN whose reflection breaks downstream metafunctions (`isa<> used on a null pointer` in display/mangling).
- `findIterableMember`: when stepping FROM such a decl (the cross-block hop lands on `*decls_begin()` of a re-opened block unchecked), use its LEXICAL context as the iteration context, so the walk continues through the namespace block instead of departing into the class's `getPrevMultDCDeclInSemaContext` chain and silently dropping every remaining member. Decls whose semantic context is a NAMESPACE (the legitimate `getLastMultDCSemaDecl` multi-context chain, e.g. `void ns::f() {}` defined at TU scope) are deliberately not rewritten.

The regression test covers: interleaved out-of-line defs in a single block, re-opened blocks *beginning* with template and non-template out-of-line definitions, full member recovery across all blocks, no definition leaking in as a member, and no duplicate enumeration through the class's own walk.

Validation (Release+assertions, AArch64/macOS): minimized repro flips from one bogus member to the three real ones; against real Eigen 5.0.1 headers, a `members_of(^^Eigen)` lift goes from crashing (or silently yielding 69 of 125 members) to clean; `clang/test/Reflection` 15/16, identical to pristine base.
