### PR TITLE
[clang][reflection] Desugar aliases in is_complete_type before triggering instantiation

### DIFF
--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -4737,12 +4737,20 @@ bool is_complete_type(APValue &Result, ASTContext &C, MetaActions &Meta,
 
   bool result = false;
   if (RV.isReflectedType()) {
+    // Desugar aliases first (exactly as the members_of family does): on a
+    // TypedefType, findTypeDecl returns the alias declaration, for which
+    // EnsureInstantiated is a no-op -- a never-yet-instantiated (but
+    // perfectly instantiable) specialization named through an alias then
+    // wrongly reported as incomplete.
+    QualType QT = desugarType(RV.getReflectedType(), /*UnwrapAliases=*/true,
+                              /*DropCV=*/false, /*DropRefs=*/false);
+
     // If this is a declared type with a reachable definition, ensure that the
     // type is instantiated.
-    if (Decl *typeDecl = findTypeDecl(RV.getReflectedType()))
+    if (Decl *typeDecl = findTypeDecl(QT))
       (void) Meta.EnsureInstantiated(typeDecl, Range);
 
-    result = !RV.getReflectedType()->isIncompleteType();
+    result = !QT->isIncompleteType();
   }
   return SetAndSucceed(Result, makeBool(C, result));
 }

--- a/libcxx/test/std/experimental/reflection/is-complete-type-alias-sugar.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/is-complete-type-alias-sugar.pass.cpp
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright 2024 Bloomberg Finance L.P.
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03 || c++11 || c++14 || c++17 || c++20
+// ADDITIONAL_COMPILE_FLAGS: -freflection-latest
+
+// <experimental/reflection>
+//
+// [reflection]
+//
+// Regression test: is_complete_type must see through ALIAS sugar before
+// triggering instantiation. It used to pass the sugared type to findTypeDecl,
+// get back the TypedefDecl (for which EnsureInstantiated is a no-op), and
+// report a never-yet-instantiated -- but perfectly instantiable --
+// specialization as incomplete. Asking about the same specialization through
+// its direct spelling first flipped the answer: order-dependent results.
+// The members_of family always desugared; is_complete_type was the gap.
+
+#include <experimental/meta>
+
+template <class T> struct Box { T v; };
+
+// Alias to a spec nothing else references: completion must be triggered
+// THROUGH the alias.
+using BoxInt = Box<int>;
+static_assert(std::meta::is_complete_type(^^BoxInt));
+
+// Member typedefs are the field shape (spdlog's sink chain reaches signatures
+// through them).
+template <class T> struct Wrap {
+  using boxed = Box<T*>;
+};
+static_assert(std::meta::is_complete_type(^^Wrap<char>::boxed));
+
+// A forward-declared-only template is incomplete through any spelling.
+template <class T> struct Undefined;
+using UndefinedInt = Undefined<int>;
+static_assert(!std::meta::is_complete_type(^^UndefinedInt));
+static_assert(!std::meta::is_complete_type(^^Undefined<long>));
+
+// Direct spellings keep working, before and after alias queries of the same
+// entity.
+using BoxLong = Box<long>;
+static_assert(std::meta::is_complete_type(^^Box<long>));
+static_assert(std::meta::is_complete_type(^^BoxLong));
+
+// Non-template shapes are unaffected.
+struct Complete {};
+struct Incomplete;
+using CompleteAlias = Complete;
+using IncompleteAlias = Incomplete;
+static_assert(std::meta::is_complete_type(^^CompleteAlias));
+static_assert(!std::meta::is_complete_type(^^IncompleteAlias));
+
+int main() { return 0; }


### PR DESCRIPTION
Fixes #304.

`is_complete_type` passed the sugared type to `findTypeDecl`, which for a `TypedefType` returns the alias declaration — `EnsureInstantiated(TypedefDecl)` is a no-op, so an instantiable but never-yet-referenced specialization named through an alias was reported incomplete, order-dependently (spelling the same specialization directly anywhere first flipped the answer). Desugar exactly as the `members_of` family (`get_begin_member_decl_of`) does before `findTypeDecl`, and test completeness on the desugared type.

Same theme as #292 (metafunctions blinded by sugar on the path to the node they inspect), different site. `has_complete_definition` intentionally untouched: it reports on the existing definition state and does not instantiate.

The regression test covers: alias to a never-referenced spec, member-typedef naming (the field shape — spdlog reaches its sink types through aliases and member typedefs), forward-declared-only templates through both spellings, direct-then-alias order, and complete/incomplete non-template controls.

Validation (Release+assertions, AArch64/macOS): test fails at base on the alias cases, passes with the fix; `clang/test/Reflection` 15/16, identical to pristine base.
