### PR TITLE
[clang] Don't crash classifying a dependent splice expression

### DIFF
--- a/clang/lib/AST/ExprClassification.cpp
+++ b/clang/lib/AST/ExprClassification.cpp
@@ -280,6 +280,13 @@ static Cl::Kinds ClassifyInternal(ASTContext &Ctx, const Expr *E) {
 
   case Expr::CXXSpliceExprClass: {
     const auto *SE = dyn_cast<CXXSpliceExpr>(E);
+    // A dependent splice has no model expression yet (BuildReflectionSpliceExpr
+    // creates it with a null model); classify it by its own value kind instead
+    // of dereferencing the null model. Reachable at parse time: DeduceAutoType
+    // classifies a dependent splice used as the argument of an `auto` non-type
+    // template parameter, e.g. in a requires-expression type-requirement.
+    if (!SE->getModel())
+      return SE->getValueKind() == VK_LValue ? Cl::CL_LValue : Cl::CL_PRValue;
     if (const auto *DRE = dyn_cast<DeclRefExpr>(SE->getModel())) {
       if (auto *MD = dyn_cast<CXXMethodDecl>(DRE->getDecl());
           MD && !MD->isStatic())

--- a/libcxx/test/std/experimental/reflection/auto-nttp-dependent-splice-requires.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/auto-nttp-dependent-splice-requires.pass.cpp
@@ -1,0 +1,60 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright 2024 Bloomberg Finance L.P.
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03 || c++11 || c++14 || c++17 || c++20
+// ADDITIONAL_COMPILE_FLAGS: -freflection-latest
+
+// <experimental/reflection>
+//
+// [reflection]
+//
+// Regression test: a DEPENDENT splice used as the argument of an `auto`
+// non-type template parameter inside a requires-expression must not crash the
+// parser. A dependent CXXSpliceExpr carries no model expression; classifying
+// it (Sema::DeduceAutoType -> Expr::ClassifyImpl) used to dyn_cast the null
+// model and trip "dyn_cast on a non-existent value" at parse time. The
+// classification now falls back to the splice's own value kind.
+
+#include <experimental/meta>
+
+template <auto> struct probe;
+template <long double> struct probe_fixed;
+
+template <std::meta::info mem>
+consteval bool value_readable_auto() {
+  // The crash fired while PARSING this requires-expression (no instantiation
+  // needed); the constant-evaluation behavior is checked below for good
+  // measure.
+  if constexpr (requires { typename probe<([:mem:])>; })
+    return true;
+  return false;
+}
+
+template <std::meta::info mem>
+consteval bool value_readable_fixed() {
+  if constexpr (requires { typename probe_fixed<(long double)([:mem:])>; })
+    return true;
+  return false;
+}
+
+struct WithInit    { static const int K = 7; };
+struct DeclaredOnly { static const int K; };
+
+int main() {
+  // Constant-readable in-class initializer: both probe forms succeed.
+  static_assert(value_readable_auto<^^WithInit::K>());
+  static_assert(value_readable_fixed<^^WithInit::K>());
+
+  // Declared-but-never-defined: not readable; the requires-clause must be a
+  // clean substitution failure, not a crash or a hard error.
+  static_assert(!value_readable_auto<^^DeclaredOnly::K>());
+  static_assert(!value_readable_fixed<^^DeclaredOnly::K>());
+  return 0;
+}


### PR DESCRIPTION
Fixes #309.

A dependent `CXXSpliceExpr` is created with a null model expression (`BuildReflectionSpliceExpr`'s dependent tail). Expr classification unconditionally dereferenced the model, so classifying a dependent splice — reachable at parse time when `Sema::DeduceAutoType` deduces an `auto` non-type template parameter from `typename probe<([:mem:])>` inside a requires-expression type-requirement — tripped `dyn_cast on a non-existent value` (Casting.h:662).

Classify a model-less splice by its own value kind instead.

Includes a regression test (`libcxx/test/std/experimental/reflection/auto-nttp-dependent-splice-requires.pass.cpp`) covering both the `auto`-NTTP and fixed-NTTP probe forms over constant-readable and declared-only static members.

Validation (Apple Silicon, Release+assertions, base `837da39`):
- the repro ICEs at pristine base and compiles clean with this change (verified both directions by reverting just this file);
- `clang/test/Reflection` is at parity with base (15/16; `splice-exprs.cpp` pre-existing);
- the new regression test passes.