### PR TITLE
[clang] Describe builtin templates instead of crashing

### DIFF
--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -1740,7 +1740,13 @@ StringRef DescriptionOf(APValue RV, bool Granular = true) {
     else if (isa<TypeAliasTemplateDecl>(TD)) return "an alias template";
     else if (isa<VarTemplateDecl>(TD)) return "a variable template";
     else if (isa<ConceptDecl>(TD)) return "a concept";
-    llvm_unreachable("unhandled template kind");
+    else if (isa<BuiltinTemplateDecl>(TD)) return "a builtin template";
+    else if (isa<TemplateTemplateParmDecl>(TD)) return "a template template parameter";
+    // DescriptionOf feeds diagnostics; describing an unanticipated kind must
+    // degrade, never crash (the global namespace enumerates builtin templates
+    // like __make_integer_seq, which reached the unreachable above through a
+    // metafunction's error path).
+    return "a template";
   }
   case ReflectionKind::Namespace: {
     Decl *D = RV.getReflectedNamespace();

--- a/libcxx/test/std/experimental/reflection/description-of-template-kinds.verify.cpp
+++ b/libcxx/test/std/experimental/reflection/description-of-template-kinds.verify.cpp
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright 2024 Bloomberg Finance L.P.
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03 || c++11 || c++14 || c++17 || c++20
+// ADDITIONAL_COMPILE_FLAGS: -freflection-latest
+
+// <experimental/reflection>
+//
+// [reflection]
+//
+// Regression test: a metafunction error DESCRIBING a builtin template (e.g.
+// __make_integer_seq, enumerable as a global-namespace member) must produce a
+// clean diagnostic, not crash. DescriptionOf's ReflectionKind::Template switch
+// had no arm for BuiltinTemplateDecl and hit llvm_unreachable("unhandled
+// template kind") while BUILDING the error note -- so any recovered/diagnosed
+// failure path that touched such a reflection ICE'd the compiler at constant
+// evaluation time (reflecting any class in the GLOBAL namespace walked into
+// one via the free-operator scan of a reflection-driven binding generator).
+
+#include <experimental/meta>
+
+consteval std::meta::info find_builtin_template() {
+  for (auto m : std::meta::members_of(^^::,
+                                      std::meta::access_context::unchecked()))
+    if (std::meta::is_template(m) && std::meta::has_identifier(m) &&
+        std::meta::identifier_of(m) == "__make_integer_seq")
+      return m;
+  return ^^void;
+}
+static_assert(find_builtin_template() != ^^void);
+
+constexpr auto r = std::meta::return_type_of(find_builtin_template());
+// expected-error@-1 {{must be initialized by a constant expression}}
+// expected-note@-2 {{cannot query the return type of a builtin template}}
+// expected-note@*:* {{subexpression not valid in a constant expression}}
+// expected-note@-4 {{in call to}}


### PR DESCRIPTION
Fixes #311.

`DescriptionOf`'s `ReflectionKind::Template` switch had no arm for `BuiltinTemplateDecl`: a metafunction error path describing one (the global namespace enumerates `__make_integer_seq` et al., reachable from any namespace-scope scan) hit `llvm_unreachable("unhandled template kind")` while building the diagnostic. Add `BuiltinTemplateDecl`/`TemplateTemplateParmDecl` arms and a generic fallback — a description helper feeding diagnostics must degrade, never crash.

Includes a verify-style regression test asserting the clean diagnostic (including the new "a builtin template" wording) on the exact field shape.

Validation (Apple Silicon, Release+assertions, base `837da39`):
- the repro ICEs at pristine base and produces the clean diagnostic with this change (verified both directions by reverting just this file);
- `clang/test/Reflection` at parity with base;
- downstream, this unblocked binding-generation for an entire global-namespace C++ library (Box2D) whose every translation unit previously crashed.
