### PR TITLE
[clang] Don't truncate member enumeration at linkage-spec typedef tags

### DIFF
--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -1433,6 +1433,18 @@ static bool ensureDeclared(ASTContext &C, QualType QT, SourceLocation SpecLoc) {
 static bool isReflectableDecl(MetaActions &Meta, ASTContext &C, Decl *D) {
   assert(D && "null declaration");
 
+  // An out-of-line definition of a class member sits lexically in a namespace
+  // but belongs semantically to its class (Eigen defines most MatrixBase
+  // members this way, in re-opened namespace blocks). It is a pure
+  // redeclaration: the entity is enumerable through its class, never through
+  // the namespace -- and a reflection of the dependent definition PATTERN
+  // (when the class is a template) breaks downstream metafunctions outright.
+  // The redeclaration check below does not catch it: the definition is the
+  // FIRST declaration in its own lexical context.
+  if (D->getDeclContext() != D->getLexicalDeclContext() &&
+      isa<CXXRecordDecl>(D->getDeclContext()))
+    return false;
+
   if (D != D->getCanonicalDecl()) {
     Decl *First = nullptr;
     for (Decl *I = D->getMostRecentDecl(); I; I = I->getPreviousDecl())
@@ -1494,6 +1506,19 @@ static Decl *findIterableMember(MetaActions &Meta, ASTContext &C, Decl *D,
 
   do {
     DeclContext *DC = D->getDeclContext();  // note: SemanticDC
+
+    // Stepping FROM an out-of-line class-member definition must walk the
+    // lexical (namespace) chain it sits in: its semantic context is the
+    // class, and consulting that would leave the enumerated namespace
+    // entirely (the cross-block hop below can land on such a definition when
+    // it is the first declaration of a re-opened namespace block -- silently
+    // dropping every remaining member). Decls whose semantic context is a
+    // NAMESPACE but whose lexical context differs are NOT rewritten: those
+    // are the legitimate getLastMultDCSemaDecl/getPrevMultDCDeclInSemaContext
+    // chain (e.g. `void ns::f() {}` defined at translation-unit scope).
+    if (DC != D->getLexicalDeclContext() && isa<CXXRecordDecl>(DC) &&
+        D->getLexicalDeclContext()->isFileContext())
+      DC = D->getLexicalDeclContext();
 
     if (D->getLexicalDeclContext() == DC) {
       // Get the next declaration in the DeclContext.

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -1520,6 +1520,18 @@ static Decl *findIterableMember(MetaActions &Meta, ASTContext &C, Decl *D,
         D->getLexicalDeclContext()->isFileContext())
       DC = D->getLexicalDeclContext();
 
+    // The implicit tag from `extern "C" { typedef struct X X; }` is
+    // semantically injected into the enclosing (file) scope but sits
+    // lexically inside the linkage-spec block. Stepping it via the semantic
+    // chain (getPrevMultDCDeclInSemaContext below) walks BACKWARD out of the
+    // block and silently ENDS the enumeration, dropping every member
+    // declared after the block -- Python.h's pytypedefs.h shape truncated
+    // members_of(^^::) mid-header. Walk the lexical block instead; the
+    // pop-out logic resumes at the enclosing scope when the block ends.
+    if (DC != D->getLexicalDeclContext() &&
+        isa<LinkageSpecDecl>(D->getLexicalDeclContext()))
+      DC = D->getLexicalDeclContext();
+
     if (D->getLexicalDeclContext() == DC) {
       // Get the next declaration in the DeclContext.
       //
@@ -1543,10 +1555,19 @@ static Decl *findIterableMember(MetaActions &Meta, ASTContext &C, Decl *D,
         if (!D) {
           auto *Canonical = cast<NamespaceDecl>(DC->getPrimaryContext());
           D = Canonical->getLastMultDCSemaDecl();
+          // Skip multi-DC decls that sit lexically inside a linkage-spec
+          // block (the implicit tag from `extern "C" { typedef struct X X; }`
+          // is semantically a namespace member): they are enumerated through
+          // the block itself, and re-entering one here would cycle the walk
+          // forever (the lexical rewrite above would re-walk the block).
+          while (D && isa<LinkageSpecDecl>(D->getLexicalDeclContext()))
+            D = D->getPrevMultDCDeclInSemaContext();
         }
       }
     } else {
       D = D->getPrevMultDCDeclInSemaContext();
+      while (D && isa<LinkageSpecDecl>(D->getLexicalDeclContext()))
+        D = D->getPrevMultDCDeclInSemaContext();
     }
 
     // We need to recursively descend into LinkageSpecDecls to iterate over the

--- a/libcxx/test/std/experimental/reflection/members-of-linkage-spec-typedef-tag.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/members-of-linkage-spec-typedef-tag.pass.cpp
@@ -1,0 +1,84 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright 2024 Bloomberg Finance L.P.
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03 || c++11 || c++14 || c++17 || c++20
+// ADDITIONAL_COMPILE_FLAGS: -freflection-latest
+
+// <experimental/reflection>
+//
+// [reflection]
+//
+// Regression test: `extern "C" { typedef struct X X; }` creates an implicit
+// tag whose SEMANTIC context is the enclosing file scope while it sits
+// LEXICALLY inside the linkage-spec block. Stepping the member walk from that
+// tag via the semantic chain walked backward out of the block and silently
+// ENDED the enumeration -- every member declared after the block vanished
+// from members_of (Python.h's pytypedefs.h truncated members_of(^^::)
+// mid-header, hiding all later global declarations from reflection).
+
+#include <experimental/meta>
+
+extern "C" {
+typedef struct PMD PMD;          // implicit tag: semantic ctx = file scope
+}
+extern "C" {
+struct PMD { int x; };           // defined in a later block (Python.h shape)
+}
+
+struct After { int y; };                                  // must stay visible
+inline bool operator==(const After &, const After &) { return true; }
+
+consteval int count_after_entities() {
+  int n = 0;
+  for (auto m : std::meta::members_of(^^::,
+                                      std::meta::access_context::unchecked())) {
+    // Identifier filter FIRST: probing is_class_type across every TU member
+    // would also exercise the (separately fixed) NEON-typedef mangling gap.
+    if (std::meta::has_identifier(m) &&
+        std::meta::identifier_of(m) == "After" &&
+        std::meta::is_type(m) && std::meta::is_class_type(m))
+      ++n;
+    if (std::meta::is_function(m) && !std::meta::is_template(m) &&
+        std::meta::is_operator_function(m)) {
+      for (auto p : std::meta::parameters_of(m)) {
+        auto t = std::meta::remove_cvref(std::meta::type_of(p));
+        if (std::meta::is_same_type(t, ^^After)) {
+          ++n;
+          break;
+        }
+      }
+    }
+  }
+  return n;
+}
+
+// The same shape inside a namespace must also keep walking.
+namespace wrapped {
+extern "C" {
+typedef struct WPMD WPMD;
+}
+struct NsAfter { int z; };
+} // namespace wrapped
+
+consteval bool ns_sees_after() {
+  for (auto m : std::meta::members_of(^^wrapped,
+                                      std::meta::access_context::unchecked()))
+    if (std::meta::has_identifier(m) &&
+        std::meta::identifier_of(m) == "NsAfter" &&
+        std::meta::is_type(m) && std::meta::is_class_type(m))
+      return true;
+  return false;
+}
+
+int main() {
+  static_assert(count_after_entities() == 2);   // the class + its operator==
+  static_assert(ns_sees_after());
+  return 0;
+}

--- a/libcxx/test/std/experimental/reflection/namespace-members-out-of-line-defs.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/namespace-members-out-of-line-defs.pass.cpp
@@ -1,0 +1,114 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright 2024 Bloomberg Finance L.P.
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03 || c++11 || c++14 || c++17 || c++20
+// ADDITIONAL_COMPILE_FLAGS: -freflection-latest
+
+// <experimental/reflection>
+//
+// [reflection]
+//
+// Regression test: an out-of-line definition of a class member at namespace
+// scope is a redeclaration of the CLASS member -- it must never be enumerated
+// as a member of the namespace, and its presence must not derail the
+// namespace walk. Two defects compounded when a RE-OPENED namespace block
+// began with such a definition (Eigen's header layout: EulerAngles.h opens
+// `namespace Eigen` with the MatrixBase<Derived>::canonicalEulerAngles
+// definition):
+//   1. the definition (for a class template, the dependent definition
+//      PATTERN) was yielded as a namespace member -- and reflections of such
+//      patterns break downstream metafunctions;
+//   2. stepping from it walked the CLASS's chain instead of the namespace's,
+//      silently dropping every remaining namespace member (members_of
+//      returned ONE wrong entry for the whole namespace).
+
+#include <experimental/meta>
+
+#include <string_view>
+
+namespace single {
+struct Plain { int f() const; };
+int Plain::f() const { return 1; }            // out-of-line, same block
+template <class T> struct Tmpl { int g() const; };
+template <class T> int Tmpl<T>::g() const { return 2; }
+inline int h() { return 3; }
+}  // namespace single
+
+namespace re {
+template <class T> struct Tmpl { int g() const; };
+inline int h() { return 3; }
+}  // namespace re
+
+namespace re {                                 // re-opened; FIRST decl is the
+template <class T> int Tmpl<T>::g() const {    // out-of-line definition PATTERN
+  return 2;
+}
+inline int k() { return 4; }
+struct Plain { int f() const; };
+}  // namespace re
+
+namespace re {                                 // re-opened again; starts with
+int Plain::f() const { return 1; }             // a NON-template out-of-line def
+inline int m() { return 5; }
+}  // namespace re
+
+consteval bool ns_has_member(std::meta::info ns, std::string_view name) {
+  for (auto m :
+       std::meta::members_of(ns, std::meta::access_context::unchecked()))
+    if (std::meta::has_identifier(m) && std::meta::identifier_of(m) == name)
+      return true;
+  return false;
+}
+
+consteval std::size_t ns_member_count(std::meta::info ns) {
+  std::size_t n = 0;
+  for (auto m :
+       std::meta::members_of(ns, std::meta::access_context::unchecked())) {
+    (void)m;
+    ++n;
+  }
+  return n;
+}
+
+int main() {
+  // Single-block namespace: out-of-line defs interleaved with members.
+  static_assert(ns_has_member(^^single, "Plain"));
+  static_assert(ns_has_member(^^single, "Tmpl"));
+  static_assert(ns_has_member(^^single, "h"));
+  static_assert(!ns_has_member(^^single, "f"));
+  static_assert(!ns_has_member(^^single, "g"));
+  static_assert(ns_member_count(^^single) == 3);
+
+  // Re-opened blocks BEGINNING with out-of-line definitions: every real
+  // member across all blocks must survive, no definition may leak in.
+  static_assert(ns_has_member(^^re, "Tmpl"));
+  static_assert(ns_has_member(^^re, "Plain"));
+  static_assert(ns_has_member(^^re, "h"));
+  static_assert(ns_has_member(^^re, "k"));
+  static_assert(ns_has_member(^^re, "m"));
+  static_assert(!ns_has_member(^^re, "g"));
+  static_assert(!ns_has_member(^^re, "f"));
+  static_assert(ns_member_count(^^re) == 5);
+
+  // The class member itself is still enumerable through its class, and the
+  // namespace-scope definition did not duplicate it.
+  static_assert(ns_member_count(^^re) == 5);
+  consteval {
+    std::size_t fs = 0;
+    for (auto m : std::meta::members_of(
+             ^^re::Plain, std::meta::access_context::unchecked()))
+      if (std::meta::has_identifier(m) && std::meta::identifier_of(m) == "f")
+        ++fs;
+    if (fs != 1)
+      __builtin_abort();
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Fixes #313. Stacks on #306 (the namespace member-walk fix this extends; only the last commit is new).

The implicit tag from `extern "C" { typedef struct X X; }` is semantically injected into the enclosing scope while sitting lexically inside the linkage-spec block. Stepping it via the semantic chain (`getPrevMultDCDeclInSemaContext`) walked BACKWARD out of the block and silently ENDED the enumeration — `members_of(^^::)` truncated at Python.h's `pytypedefs.h`, hiding every later declaration from reflection.

Two halves:
- stepping from a decl whose lexical context is a `LinkageSpecDecl` walks the LEXICAL block (the existing pop-out logic resumes the enclosing scope at block end), mirroring the out-of-line-member rewrite this stacks on;
- the namespace multi-DC tail-hop skips linkage-spec-lexical decls — they are enumerated through the block itself, and re-entering one cycles the walk forever (caught by the regression test's namespace case).

Includes a regression test covering both the translation-unit and namespace shapes.

Validation (Apple Silicon, Release+assertions): repro fails at the stack base and passes with this change (verified both directions by reverting just this file); `clang/test/Reflection` at parity; regression test passes.
