### PR TITLE
[clang] Handle LP64 long-element NEON vectors in the Itanium mangler

### DIFF
--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -4017,6 +4017,8 @@ void CXXNameMangler::mangleNeonVectorType(const VectorType *T) {
     case BuiltinType::UShort:
       EltName = "poly16_t";
       break;
+    case BuiltinType::Long:
+    case BuiltinType::ULong:
     case BuiltinType::LongLong:
     case BuiltinType::ULongLong:
       EltName = "poly64_t";
@@ -4033,6 +4035,11 @@ void CXXNameMangler::mangleNeonVectorType(const VectorType *T) {
     case BuiltinType::UInt:      EltName = "uint32_t"; break;
     case BuiltinType::LongLong:  EltName = "int64_t"; break;
     case BuiltinType::ULongLong: EltName = "uint64_t"; break;
+    // LP64 targets (Darwin AArch64) predeclare the 64-bit NEON element as
+    // plain long; reflection's eager instantiation over the predeclared
+    // global typedefs (__Int64x1_t et al.) mangles these specializations.
+    case BuiltinType::Long:      EltName = "int64_t"; break;
+    case BuiltinType::ULong:     EltName = "uint64_t"; break;
     case BuiltinType::Double:    EltName = "float64_t"; break;
     case BuiltinType::Float:     EltName = "float32_t"; break;
     case BuiltinType::Half:      EltName = "float16_t"; break;


### PR DESCRIPTION
Fixes #314.

LP64 targets (Darwin AArch64) predeclare the 64-bit NEON element type as plain `long`; `mangleNeonVectorType`'s switches only handled `LongLong`/`ULongLong` and hit `llvm_unreachable("unexpected Neon vector element type")` — reachable whenever an instantiation over the predeclared global typedefs (`__Int64x1_t` et al.) is mangled, which reflection's enumeration of translation-unit members makes easy. Add `Long`/`ULong` arms (`int64_t`/`uint64_t`, and `poly64_t` in the polynomial switch).

Validation (Apple Silicon, Release+assertions, base `837da39`): the repro ICEs at pristine base and compiles clean with this change (verified both directions by reverting just this file); `clang/test/Reflection` at parity.
