### PR TITLE
[clang][P2996] Make parameter-name queries independent of instantiation state

### DIFF
--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -1099,6 +1099,24 @@ static bool getParameterName(ParmVarDecl *PVD, std::string &Out) {
   // a function declaration, since the DeclContext is not the function but the
   // TranslationUnitDecl.
   FunctionDecl *FD = cast<FunctionDecl>(PVD->getDeclContext());
+
+  // For an instantiated member, instantiating the out-of-line definition
+  // REPLACES the parameters on the same FunctionDecl (no redeclaration is
+  // added), so walking the instantiation's chain reads whichever
+  // redeclaration happened to be instantiated last -- the answer would
+  // depend on instantiation state and could differ between translation
+  // units reflecting the same entity. The template pattern carries the
+  // full declaration chain regardless of instantiation state, so walk
+  // that instead. (Skipped when the pattern contains a parameter pack:
+  // its parameter list does not line up index-for-index with the
+  // instantiation's, and pack-substituted parameters were already
+  // filtered above.)
+  if (FunctionDecl *Pattern = FD->getTemplateInstantiationPattern();
+      Pattern && llvm::none_of(Pattern->parameters(), [](const ParmVarDecl *P) {
+        return P->isParameterPack();
+      }))
+    FD = Pattern;
+
   FD = FD->getMostRecentDecl();
   PVD = FD->getParamDecl(ParamIdx);
 

--- a/libcxx/test/std/experimental/reflection/param-name-consistency-instantiation.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/param-name-consistency-instantiation.pass.cpp
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// ADDITIONAL_COMPILE_FLAGS: -freflection-latest -fparameter-reflection
+
+// <experimental/meta>
+
+// RUN: %{build}
+// RUN: %{exec} %t.exe
+
+// Parameter-name queries must not depend on instantiation state. A member
+// whose in-class declaration and out-of-line definition name a parameter
+// differently has NO consistent name; instantiating the definition (which
+// replaces the parameters on the instantiated FunctionDecl in place) must
+// not change the answer. The consistency walk goes through the template
+// pattern's full declaration chain.
+
+#include <experimental/meta>
+#include <string_view>
+
+using namespace std::meta;
+
+template <class T> struct S {
+  void f(int value);   // inconsistent: the definition says "val"
+  void g(int width);   // consistent across declaration + definition
+};
+template <class T> void S<T>::f(int val) {}
+template <class T> void S<T>::g(int width) {}
+
+// Instantiate the definitions BEFORE the queries: pre-fix this flipped f's
+// reported parameter name from "value" to "val".
+template void S<int>::f(int);
+template void S<int>::g(int);
+
+consteval info param0(std::string_view name) {
+  for (auto m : members_of(^^S<int>, access_context::unchecked()))
+    if (is_function(m) && has_identifier(m) && identifier_of(m) == name)
+      return parameters_of(m)[0];
+  return {};
+}
+
+static_assert(!has_identifier(param0("f")));
+static_assert(has_identifier(param0("g")));
+static_assert(identifier_of(param0("g")) == "width");
+
+int main(int, char**) { return 0; }


### PR DESCRIPTION
Fixes #322.

The P3096 consistency walk in `getParameterName` (report no identifier when redeclarations disagree on a parameter name) ran over the function's redeclaration chain — but for an instantiated member, instantiating the out-of-line definition REPLACES the parameters on the same `FunctionDecl` without adding a redeclaration, so the walk saw exactly one name: whichever redeclaration happened to be instantiated last. The same query on the same entity answered differently depending on instantiation state, and two TUs reflecting the same entity could disagree (field shape: Eigen's `DenseBase::setConstant`, declared with `value`, defined with `val`).

Fix: walk the template instantiation pattern's declaration chain, which carries the in-class declaration and the out-of-line definition regardless of instantiation state. Skipped when the pattern contains a parameter pack (its parameter list does not line up index-for-index with the instantiation's; pack-substituted parameters were already filtered earlier in the function). An inconsistently-named parameter now deterministically has no identifier; consistently-named parameters keep their name.

Adds `libcxx/test/std/experimental/reflection/param-name-consistency-instantiation.pass.cpp`: the pre-fix flip trigger (explicit instantiation of the definition before the query) plus a consistently-named control.

Validated on a Release+assertions AArch64/macOS build of this branch: the repro flips answers at the base commit and is deterministic with the fix; `clang/test/Reflection` parity with base; found and exercised by differential surface-comparison of two independently generated Python binding modules over Eigen.
