### PR TITLE
clang: fix crash on expansion statement over an overload set

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -3262,6 +3262,9 @@ def err_injected_decl_outside_cone : Error <
 
 def err_compute_expansion_size_index : Error<
   "could not compute %select{size|index}0 of expansion">;
+def err_expansion_stmt_range_is_function : Error<
+  "cannot expand over a function %0; did you mean to call it "
+  "with no arguments?">;
 def err_expanded_identifier_label : Error<
   "identifier labels are not allowed in expansion statements">;
 

--- a/clang/lib/Sema/SemaExpand.cpp
+++ b/clang/lib/Sema/SemaExpand.cpp
@@ -429,6 +429,14 @@ StmtResult Sema::BuildCXXInitListExpansionStmt(SourceLocation TemplateKWLoc,
 ExprResult Sema::BuildCXXExpansionSelectExpr(
     Expr *Range, Expr *TParamRef, VarDecl *ExpansionVar,
     ArrayRef <MaterializeTemporaryExpr *> LifetimeExtendTemps) {
+
+  if (Range->hasPlaceholderType() && !Range->isTypeDependent()) {
+    ExprResult R = CheckPlaceholderExpr(Range);
+    if (R.isInvalid())
+      return ExprError();
+    Range = R.get();
+  }
+
   if (Range->containsErrors())
     return ExprError();
 

--- a/clang/lib/Sema/SemaExpand.cpp
+++ b/clang/lib/Sema/SemaExpand.cpp
@@ -14,6 +14,8 @@
 
 #include "clang/AST/Decl.h"
 #include "clang/AST/DynamicRecursiveASTVisitor.h"
+#include "clang/AST/Type.h"
+#include "clang/Basic/DiagnosticParse.h"
 #include "clang/Basic/DiagnosticSema.h"
 #include "clang/Lex/Preprocessor.h"
 #include "clang/Sema/EnterExpressionEvaluationContext.h"
@@ -435,6 +437,17 @@ ExprResult Sema::BuildCXXExpansionSelectExpr(
     if (R.isInvalid())
       return ExprError();
     Range = R.get();
+  }
+
+  if (!Range->isTypeDependent()) {
+    QualType RangeTy = Range->getType().getNonReferenceType();
+    if (RangeTy->isFunctionType() || (RangeTy->isPointerType() && RangeTy->getPointeeType()->isFunctionType())) {
+      ExprResult R = Range;
+      tryToRecoverWithCall(
+          R, PDiag(diag::err_expansion_stmt_range_is_function) << RangeTy,
+          /*ForceComplete=*/false);
+      return ExprError();
+    }
   }
 
   if (Range->containsErrors())

--- a/clang/lib/Sema/SemaExpand.cpp
+++ b/clang/lib/Sema/SemaExpand.cpp
@@ -441,7 +441,9 @@ ExprResult Sema::BuildCXXExpansionSelectExpr(
 
   if (!Range->isTypeDependent()) {
     QualType RangeTy = Range->getType().getNonReferenceType();
-    if (RangeTy->isFunctionType() || (RangeTy->isPointerType() && RangeTy->getPointeeType()->isFunctionType())) {
+    if (RangeTy->isFunctionType() ||
+       (RangeTy->isPointerType() &&
+        RangeTy->getPointeeType()->isFunctionType())) {
       ExprResult R = Range;
       tryToRecoverWithCall(
           R, PDiag(diag::err_expansion_stmt_range_is_function) << RangeTy,

--- a/clang/test/Reflection/expansion-statements-overload-range.cpp
+++ b/clang/test/Reflection/expansion-statements-overload-range.cpp
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright 2024 Bloomberg Finance L.P.
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// RUN: %clang_cc1 -std=c++2c -freflection-latest -fexpansion-statements -fsyntax-only -verify %s
+
+void f();          // expected-note {{possible target for call}}
+void f(int) {      // expected-note {{possible target for call}}
+  template for (auto x : f); // expected-error {{reference to overloaded function could not be resolved; did you mean to call it?}}
+}
+
+int g();
+void h() {
+  template for (auto x : g); // expected-error {{cannot expand over a function 'int ()'; did you mean to call it with no arguments?}}
+}
+
+// With pointer
+void h2() {
+  int (*fp)() = g;
+  template for (auto x : fp); // expected-error {{cannot expand over a function 'int (*)()'}}
+}
+
+template <typename T> int dep();
+template <typename T>
+void inst() {
+  template for (auto x : dep<T>); // expected-error {{cannot expand over a function 'int ()'; did you mean to call it with no arguments?}}
+}
+template void inst<int>(); // expected-note {{in instantiation of function template specialization 'inst<int>' requested here}}


### PR DESCRIPTION
Fixes #327 

**Changes**
- `Sema::BuildCXXExpansionSelectExpr()`: added a check for a placeholder type on the range expression and a call to `CheckPlaceholderExpr()` to resolve it
- Added a more specific diagnostic (with a fix-it hint) for expanding over an uncalled zero-argument function: "cannot expand over a function ...; did you mean to call it with no arguments?"
- Added regression test at `clang/test/Reflection/expansion-statements-overload-range.cpp`

**Additional changes**
The code from #326 (even after the patch in `Sema::BuildCXXExpansionSelectExpr()`) produces a fairly blunt error, so I added a more informative diagnostic with a fix-it hint (unfortunately, I forgot to save it, and I'm too lazy to recompile):
```
$ E:/p2996/build/bin/clang++ -std=c++26 -freflection-latest   -nostdinc++ -isystem /e/p2996/build/include/c++/v1   test1.cpp
test1.cpp:26:50: error: cannot expand over a function 'span<const ranges::range_value_t<std::vector<meta::info,
      std::allocator<meta::info>>>> ()' (aka 'span<const meta::info> ()'); did you mean to call it with no arguments?
   26 |             constexpr const std::meta::info& i : T_members<T>) // Fixing the call to be T_members<T>(), works.
      |                                                  ^~~~~~~~~~~~
      |                                                              ()
test1.cpp:38:14: note: in instantiation of member function 'A<S>::m' requested here
   38 |     return t.m(a);
      |              ^
1 error generated.
```