### PR TITLE
[Clang][P2996] Implement PCH serialization for ExplDependentCallExpr

### DIFF
--- a/clang/include/clang/AST/ExprCXX.h
+++ b/clang/include/clang/AST/ExprCXX.h
@@ -5718,18 +5718,23 @@ class ExplDependentCallExpr : public Expr {
   Expr *SubExpr;
 
   ExplDependentCallExpr(Expr *SubExpr, unsigned TemplateDepth);
+  ExplDependentCallExpr(EmptyShell Empty) : Expr(ExplDependentCallExprClass,
+                                                 Empty) {}
 
 public:
   static ExplDependentCallExpr *Create(ASTContext &C, Expr *SubExpr,
                                        unsigned TemplateDepth);
+  static ExplDependentCallExpr *CreateEmpty(ASTContext &C);
 
   Expr *getSubExpr() const {
     return SubExpr;
   }
+  void setSubExpr(Expr *E) { SubExpr = E; }
 
   int getTemplateDepth() const {
     return TemplateDepth;
   }
+  void setTemplateDepth(unsigned Depth) { TemplateDepth = Depth; }
 
   SourceLocation getBeginLoc() const {
     return SubExpr->getBeginLoc();

--- a/clang/lib/AST/ExprCXX.cpp
+++ b/clang/lib/AST/ExprCXX.cpp
@@ -2090,6 +2090,10 @@ ExplDependentCallExpr *ExplDependentCallExpr::Create(ASTContext &C,
   return new (C) ExplDependentCallExpr(SubExpr, TemplateDepth);
 }
 
+ExplDependentCallExpr *ExplDependentCallExpr::CreateEmpty(ASTContext &C) {
+  return new (C) ExplDependentCallExpr(EmptyShell());
+}
+
 CXXDependentMemberSpliceExpr::CXXDependentMemberSpliceExpr(
         QualType ResultTy, Expr *Base, SourceLocation OpLoc, bool IsArrow,
         CXXSpliceExpr *RHS)

--- a/clang/lib/Serialization/ASTReaderStmt.cpp
+++ b/clang/lib/Serialization/ASTReaderStmt.cpp
@@ -548,7 +548,9 @@ void ASTStmtReader::VisitExtractLValueExpr(ExtractLValueExpr *E) {
 }
 
 void ASTStmtReader::VisitExplDependentCallExpr(ExplDependentCallExpr *E) {
-  llvm_unreachable("unimplemented");
+  VisitExpr(E);
+  E->setTemplateDepth(Record.readUInt32());
+  E->setSubExpr(Record.readExpr());
 }
 
 void ASTStmtReader::VisitCXXExpansionStmt(CXXExpansionStmt *S) {
@@ -4657,6 +4659,10 @@ Stmt *ASTReader::ReadStmtFromStream(ModuleFile &F) {
     }
     case EXPR_METAFUNCTION: {
       S = CXXMetafunctionExpr::CreateEmpty(Context);
+      break;
+    }
+    case EXPR_EXPL_DEPENDENT_CALL: {
+      S = ExplDependentCallExpr::CreateEmpty(Context);
       break;
     }
     case EXPR_SPLICE: {

--- a/clang/lib/Serialization/ASTWriterStmt.cpp
+++ b/clang/lib/Serialization/ASTWriterStmt.cpp
@@ -531,7 +531,8 @@ void ASTStmtWriter::VisitExtractLValueExpr(ExtractLValueExpr *E) {
 
 void ASTStmtWriter::VisitExplDependentCallExpr(ExplDependentCallExpr *E) {
   VisitExpr(E);
-  // TODO(P2996): Implement this.
+  Record.writeUInt32(E->getTemplateDepth());
+  Record.AddStmt(E->getSubExpr());
   Code = serialization::EXPR_EXPL_DEPENDENT_CALL;
 }
 

--- a/clang/test/PCH/expl-dependent-call.cpp
+++ b/clang/test/PCH/expl-dependent-call.cpp
@@ -1,0 +1,26 @@
+// This covers PCH serialization of ExplDependentCallExpr (bloomberg/clang-p2996#329).
+// RUN: %clang_cc1 -std=c++2c -freflection -ast-dump %s | FileCheck %s
+// RUN: %clang_cc1 -std=c++2c -freflection -emit-pch %s -o %t
+// RUN: %clang_cc1 -std=c++2c -freflection -include-pch %t -verify %s
+// expected-no-diagnostics
+
+// CHECK: ExplDependentCallExpr
+
+#ifndef HEADER_INCLUDED
+#define HEADER_INCLUDED
+
+struct AccessContext {
+  [[clang::instantiation_dependent]]
+  static consteval int current() { return 42; }
+};
+
+template <typename T>
+consteval int call_current(T) {
+  return AccessContext::current();
+}
+
+#else
+
+static_assert(call_current(0) == 42);
+
+#endif


### PR DESCRIPTION
Issue number of the reported bug or feature request: #329

**Describe your changes**
ExplDependentCallExpr (the P2996-specific node wrapping calls to functions marked [[clang::instantiation_dependent]], e.g. access_context::current()) had no working PCH round-trip: the writer emitted the record without its operands (`TODO(P2996)` in ASTWriterStmt), and the reader had no construction case for the node, so its Visit method was unreachable. Consuming a PCH containing the node aborted on the record-consumption assertion in assertion builds and segfaulted in the constant evaluator in release builds (matching the original report).

This implements the missing serialization: an EmptyShell constructor and CreateEmpty for the reader's construction switch, and symmetric write/read of the template depth and wrapped call expression.

**Testing performed**
- New test `clang/test/PCH/expl-dependent-call.cpp` fails on an unpatched
  build (record-consumption assertion) and passes with this change. It also
  pins the node's presence via `-ast-dump` + FileCheck so it cannot
  silently degrade if node-creation conditions change.
- The reduced and original reproducers from #329 both pass with freshly
  generated PCHs on the patched build.
- Ran the PCH, Reflection, and Modules lit suites. 12 tests fail in my
  environment, but all 12 fail identically on the unpatched baseline; they
  are pre-existing and unrelated to this change.

**Additional context**
Found while compiling reflection-heavy code through clangd's
precompiled-preamble path; the standalone reproducer in #329 does not
require clangd.

Fixes #329.