### PR TITLE
Drop identifier_of and add namespace and token introspection

### DIFF
--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -750,6 +750,24 @@ static bool has_attribute(APValue &Result, ASTContext &C,
                          QualType ResultTy, SourceRange Range,
                          ArrayRef<Expr *> Args, Decl *ContainingDecl);
 
+static bool has_attribute_namespace(APValue &Result, ASTContext &C,
+                         MetaActions &Meta, EvalFn Evaluator,
+                         DiagFn Diagnoser, bool AllowInjection,
+                         QualType ResultTy, SourceRange Range,
+                         ArrayRef<Expr *> Args, Decl *ContainingDecl);
+
+static bool attribute_token_of(APValue &Result, ASTContext &C,
+                         MetaActions &Meta, EvalFn Evaluator,
+                         DiagFn Diagnoser, bool AllowInjection,
+                         QualType ResultTy, SourceRange Range,
+                         ArrayRef<Expr *> Args, Decl *ContainingDecl);
+
+static bool attribute_namespace_of(APValue &Result, ASTContext &C,
+                         MetaActions &Meta, EvalFn Evaluator,
+                         DiagFn Diagnoser, bool AllowInjection,
+                         QualType ResultTy, SourceRange Range,
+                         ArrayRef<Expr *> Args, Decl *ContainingDecl);
+
                           // =========================
                           // Accessibility API (P3493)
                           // =========================
@@ -921,6 +939,9 @@ static constexpr Metafunction Metafunctions[] = {
   { Metafunction::MFRK_metaInfo, 3, 3, get_ith_attribute_of },
   { Metafunction::MFRK_bool, 1, 1, is_attribute },
   { Metafunction::MFRK_bool, 3, 3, has_attribute },
+  { Metafunction::MFRK_bool, 1, 1, has_attribute_namespace },
+  { Metafunction::MFRK_spliceFromArg, 3, 3, attribute_token_of },
+  { Metafunction::MFRK_spliceFromArg, 3, 3, attribute_namespace_of },
 
   // P3493 accessibility extensions
   { Metafunction::MFRK_metaInfo, 0, 0, current_access_context },
@@ -1837,6 +1858,89 @@ struct AttributeScratchpad {
 // Metafunction implementations
 // -----------------------------------------------------------------------------
 
+bool has_attribute_namespace(APValue &Result, ASTContext &C,
+                         MetaActions &Meta, EvalFn Evaluator,
+                         DiagFn Diagnoser, bool AllowInjection,
+                         QualType ResultTy, SourceRange Range,
+                         ArrayRef<Expr *> Args, Decl *ContainingDecl) {
+  assert(Args[0]->getType()->isReflectionType());
+  assert(ResultTy == C.BoolTy);
+  APValue RV;
+  if (!Evaluator(RV, Args[0], true))
+    return true;
+  if (RV.getReflectionKind() != ReflectionKind::Attribute) {
+    return SetAndSucceed(Result, makeBool(C, false));
+  }
+  ParsedAttr *attr = RV.getReflectedAttribute();
+
+  return SetAndSucceed(
+    Result,
+    makeBool(C, attr->getForm().getSyntax() == AttributeCommonInfo::Syntax::AS_CXX11 && attr->hasScope())
+  );
+}
+
+bool attribute_namespace_of(APValue &Result, ASTContext &C,
+                         MetaActions &Meta, EvalFn Evaluator,
+                         DiagFn Diagnoser, bool AllowInjection,
+                         QualType ResultTy, SourceRange Range,
+                         ArrayRef<Expr *> Args, Decl *ContainingDecl) {
+  assert(Args[0]->getType()->isReflectionType());
+
+  APValue RV;
+  if (!Evaluator(RV, Args[1], true))
+    return true;
+
+  bool IsUtf8;
+  {
+    APValue Scratch;
+    if (!Evaluator(Scratch, Args[2], true))
+      return true;
+    IsUtf8 = Scratch.getInt().getBoolValue();
+  }
+
+  if (RV.getReflectionKind() != ReflectionKind::Attribute)
+    return DiagnoseReflectionKind(Diagnoser, Range, "an attribute", DescriptionOf(RV));
+
+  auto name(RV.getReflectedAttribute()->getNormalizedScopeName());
+  if (name.empty())
+    return Diagnoser(Range.getBegin(), diag::metafn_anonymous_entity) << DescriptionOf(RV) << Range;
+
+  Expr *StrLit = makeStrLiteral(name, C, IsUtf8);
+  APValue::LValuePathEntry Path[1] = {APValue::LValuePathEntry::ArrayIndex(0)};
+  return SetAndSucceed(Result, APValue(StrLit, CharUnits::Zero(), Path, false));
+}
+
+bool attribute_token_of(APValue &Result, ASTContext &C,
+                         MetaActions &Meta, EvalFn Evaluator,
+                         DiagFn Diagnoser, bool AllowInjection,
+                         QualType ResultTy, SourceRange Range,
+                         ArrayRef<Expr *> Args, Decl *ContainingDecl) {
+  assert(Args[0]->getType()->isReflectionType());
+
+  APValue RV;
+  if (!Evaluator(RV, Args[1], true))
+    return true;
+
+  bool IsUtf8;
+  {
+    APValue Scratch;
+    if (!Evaluator(Scratch, Args[2], true))
+      return true;
+    IsUtf8 = Scratch.getInt().getBoolValue();
+  }
+
+  if (RV.getReflectionKind() != ReflectionKind::Attribute)
+    return DiagnoseReflectionKind(Diagnoser, Range, "an attribute", DescriptionOf(RV));
+
+  auto name(RV.getReflectedAttribute()->getAttrName()->getName());
+  if (name.empty())
+    return Diagnoser(Range.getBegin(), diag::metafn_anonymous_entity) << DescriptionOf(RV) << Range;
+
+  Expr *StrLit = makeStrLiteral(name, C, IsUtf8);
+  APValue::LValuePathEntry Path[1] = {APValue::LValuePathEntry::ArrayIndex(0)};
+  return SetAndSucceed(Result, APValue(StrLit, CharUnits::Zero(), Path, false));
+}
+
 bool is_unscoped_attribute(APValue &Result, ASTContext &C,
                          MetaActions &Meta, EvalFn Evaluator,
                          DiagFn Diagnoser, bool AllowInjection,
@@ -2635,19 +2739,6 @@ bool identifier_of(APValue &Result, ASTContext &C, MetaActions &Meta,
     getDeclName(Name, C, RV.getReflectedNamespace());
     break;
   }
-  case ReflectionKind::Attribute: {
-    AttributeCommonInfo *attr = RV.getReflectedAttribute();
-    if (attr->isClangScope()) {
-      Name = "clang::";
-    } else if (attr->isGNUScope()) {
-      Name = "gnu::";
-    } else if (attr->hasScope() &&
-               attr->getScopeName()->getName().compare("msvc") == 0) {
-      Name = "msvc::";
-    }
-    Name += attr->getAttrName()->getName();
-    break;
-  }
   case ReflectionKind::DataMemberSpec: {
     TagDataMemberSpec *TDMS = RV.getReflectedDataMemberSpec();
     if (TDMS->Name)
@@ -2668,6 +2759,7 @@ bool identifier_of(APValue &Result, ASTContext &C, MetaActions &Meta,
   case ReflectionKind::Object:
   case ReflectionKind::Value:
   case ReflectionKind::Annotation:
+  case ReflectionKind::Attribute:
     return Diagnoser(Range.getBegin(), diag::metafn_cannot_have_name)
         << DescriptionOf(RV) << Range;
   case ReflectionKind::EntityProxy:

--- a/libcxx/include/meta
+++ b/libcxx/include/meta
@@ -366,6 +366,9 @@ consteval auto annotate(info) -> info;
 // Attributes reflection (P3385)
 consteval auto is_attribute(info) -> bool;
 consteval auto attributes_of(info r) -> vector<info>;
+consteval auto attribute_namespace_of(info r) -> string_view;
+consteval auto attribute_token_of(info r) -> string_view;
+consteval auto has_attribute_namespace(info r) -> bool;
 
 // modeling access control (P3547)
 struct access_context {
@@ -576,6 +579,9 @@ enum : unsigned {
   __metafn_get_ith_attribute_of,
   __metafn_is_attribute,
   __metafn_has_attribute,
+  __metafn_has_attribute_namespace,
+  __metafn_attribute_token_of,
+  __metafn_attribute_namespace_of,
 
   // P3493 accessibility metafunctions
   __metafn_access_context,
@@ -2154,6 +2160,30 @@ consteval auto has_attribute(
   return __metafunction(detail::__metafn_has_attribute, entity, attribute, policy);
 }
 
+consteval auto has_attribute_namespace(info entity) -> bool {
+  return __metafunction(detail::__metafn_has_attribute_namespace, entity);
+}
+
+consteval auto attribute_token_of(info entity) -> string_view {
+  return __metafunction(detail::__metafn_attribute_token_of, ^^const char *,
+                        entity, /*UTF8=*/false);
+}
+
+consteval auto attribute_namespace_of(info entity) -> string_view {
+  return __metafunction(detail::__metafn_attribute_namespace_of, ^^const char *,
+                        entity, /*UTF8=*/false);
+}
+
+consteval auto u8attribute_token_of(info entity) -> u8string_view {
+  return __metafunction(detail::__metafn_attribute_token_of, ^^const char8_t *,
+                        entity, /*UTF8=*/true);
+}
+
+consteval auto u8attribute_namespace_of(info entity) -> u8string_view {
+  return __metafunction(detail::__metafn_attribute_namespace_of, ^^const char8_t *,
+                        entity, /*UTF8=*/true);
+}
+
 // Returns whether the reflected entity is a clang scoped attribute.
 consteval auto is_unscoped_attribute(info r) -> bool {
   return __metafunction(detail::__metafn_is_unscoped_attribute, r);
@@ -2189,34 +2219,22 @@ consteval auto attributes_of(info r) -> vector<info> {
 consteval auto attributes_of(info r,
                              std::string_view    name,
                              AttributeNamespace ns = AttributeNamespace::None) -> vector<info> {
-  using namespace std::literals;
-
-  // For demo purpose, it's ok enough
-  // Alternative is to pass it up to the metafunction but we'd have to break our stateless iterator
-  // model.... For now, it s just not worth it (again, it's a demo).
-  auto getIdPart = [](std::string_view token) {
-    if (auto sep = token.find("::"sv); sep != std::string_view::npos && sep + 2 < token.size() ) {
-      return token.substr(sep + 2);
-    }
-    return std::string_view{};
-  };
-
   auto all = attributes_of(r);
   vector<info> result;
   for (auto attribute : all) {
     bool match = false;
     switch (ns) {
       case AttributeNamespace::None:
-        match = is_unscoped_attribute(attribute) && identifier_of(attribute) == name;
+        match = is_unscoped_attribute(attribute) && attribute_token_of(attribute) == name;
         break;
       case AttributeNamespace::Clang:
-        match = is_clang_attribute(attribute) && getIdPart(identifier_of(attribute)) == name;
+        match = is_clang_attribute(attribute) && attribute_token_of(attribute) == name;
         break;
       case AttributeNamespace::GCC:
-        match = is_gcc_attribute(attribute) && getIdPart(identifier_of(attribute)) == name;
+        match = is_gcc_attribute(attribute) && attribute_token_of(attribute) == name;
         break;
       case AttributeNamespace::MSVC:
-        match = is_msvc_attribute(attribute) && getIdPart(identifier_of(attribute)) == name;
+        match = is_msvc_attribute(attribute) && attribute_token_of(attribute) == name;
         break;
       default: break;
     }

--- a/libcxx/test/std/experimental/reflection/p3385-attributes.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/p3385-attributes.pass.cpp
@@ -62,11 +62,26 @@ consteval bool testIsAttribute() {
   return true;
 }
 
-consteval bool testIdentifierOf() {
-  static_assert(std::meta::identifier_of(stdAttr) == "nodiscard");
-  static_assert(std::meta::identifier_of(clangAttr) == "clang::warn_unused_result");
-  static_assert(std::meta::identifier_of(msvcAttr) == "msvc::no_unique_address");
-  static_assert(std::meta::identifier_of(gnuAttr) == "gnu::constructor");
+consteval bool testAttributeTokenOf() {
+  static_assert(std::meta::attribute_token_of(stdAttr) == "nodiscard");
+  static_assert(std::meta::attribute_token_of(clangAttr) == "warn_unused_result");
+  static_assert(std::meta::attribute_token_of(msvcAttr) == "no_unique_address");
+  static_assert(std::meta::attribute_token_of(gnuAttr) == "constructor");
+  return true;
+}
+
+consteval bool testHasAttributeNamespace() {
+  static_assert(!std::meta::has_attribute_namespace(stdAttr));
+  static_assert(std::meta::has_attribute_namespace(clangAttr));
+  static_assert(std::meta::has_attribute_namespace(msvcAttr));
+  static_assert(std::meta::has_attribute_namespace(gnuAttr));
+  return true;
+}
+
+consteval bool testAttributeNamespaceOf() {
+  static_assert(std::meta::attribute_namespace_of(clangAttr) == "clang");
+  static_assert(std::meta::attribute_namespace_of(msvcAttr) == "msvc");
+  static_assert(std::meta::attribute_namespace_of(gnuAttr) == "gnu");
   return true;
 }
 

--- a/libcxx/test/std/experimental/reflection/p3385-function-attributes.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/p3385-function-attributes.pass.cpp
@@ -23,7 +23,7 @@
 
 consteval bool testAttributesOfFunc() {
   static_assert(attributes_of(^^func).size() == 1);
-  static_assert(identifier_of(attributes_of(^^func)[0]) == "nodiscard");
+  static_assert(attribute_token_of(attributes_of(^^func)[0]) == "nodiscard");
   static_assert(attributes_of(^^func)[0] == ^^[[nodiscard]]);
   return true;
 }


### PR DESCRIPTION

**Describe your changes**
There is no such thing as an identifier in an attribute namespace or token, so drop that ill named metafunction, add some more suitable replacement

**Testing performed**
LIT tests

**Additional context**
Part of R9 for 3385