### PR TITLE
define_unscoped_enum

### DIFF
--- a/P2996.md
+++ b/P2996.md
@@ -48,7 +48,7 @@ The following additional experimental features can be enabled on top of `-frefle
 - Consteval blocks as proposed by [P3289](https://wg21.link/p3289).
 - Newly proposed reflection syntax from [P3381](https://wg21.link/p3381).
 - Attributes reflection from [p3385](https://wg21.link/p3385) (`-fattribute-reflection`)
-- `define_enum` from [TBD](https://wg21.link/pTBD)
+- `define_enum` and `define_unscoped_enum` from [P4033](https://wg21.link/p4033)
 
 For convenience, a unified `-freflection-latest` flag enables all of these features. Note that this fork does not implement any features proposed by P3294 ("Code Injection with Token Sequences").
 

--- a/clang/include/clang/Basic/DiagnosticMetafnKinds.td
+++ b/clang/include/clang/Basic/DiagnosticMetafnKinds.td
@@ -120,6 +120,8 @@ def metafn_injected_decl_non_plainly_consteval : Note<
 
 // define_enum
 def metafn_enum_already_complete: Note<"%0 already has enumerators defined">;
+def metafn_enum_not_scoped : Note<"%0 is not a scoped enumeration type">;
+def metafn_enum_not_unscoped : Note<"%0 is not an unscoped enumeration type">;
 // Annotation injection.
 def metafn_cannot_annotate : Note<"cannot attach an annotation to %1">;
 

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -618,6 +618,12 @@ static bool define_enum(APValue &Result, ASTContext &C, MetaActions &Meta,
                              SourceRange Range, ArrayRef<Expr *> Args,
                              Decl *ContainingDecl);
 
+static bool define_unscoped_enum(APValue &Result, ASTContext &C,
+                             MetaActions &Meta, EvalFn Evaluator,
+                             DiagFn Diagnoser, bool AllowInjection,
+                             QualType ResultTy, SourceRange Range,
+                             ArrayRef<Expr *> Args, Decl *ContainingDecl);
+
 static bool offset_of(APValue &Result, ASTContext &C, MetaActions &Meta,
                       EvalFn Evaluator, DiagFn Diagnoser, bool AllowInjection,
                       QualType ResultTy, SourceRange Range,
@@ -950,6 +956,9 @@ static constexpr Metafunction Metafunctions[] = {
   // Other bespoke functions (not proposed at this time)
   { Metafunction::MFRK_bool, 1, 1, is_access_specified },
   { Metafunction::MFRK_metaInfo, 5, 5, reflect_invoke },
+
+  // P4033 extension: completing unscoped (C-style) enums
+  { Metafunction::MFRK_metaInfo, 3, 3, define_unscoped_enum },
 };
 constexpr const unsigned NumMetafunctions = sizeof(Metafunctions) /
                                             sizeof(Metafunction);
@@ -5928,10 +5937,11 @@ bool is_enumerator_spec(APValue &Result, ASTContext &C,
   return SetAndSucceed(Result, makeBool(C, RV.isReflectedEnumMemberSpec()));
 }
 
-bool define_enum(APValue &Result, ASTContext &C, MetaActions &Meta,
-                 EvalFn Evaluator, DiagFn Diagnoser, bool AllowInjection,
-                 QualType ResultTy, SourceRange Range, ArrayRef<Expr *> Args,
-                 Decl *ContainingDecl) {
+static bool defineEnumImpl(APValue &Result, ASTContext &C, MetaActions &Meta,
+                           EvalFn Evaluator, DiagFn Diagnoser,
+                           bool AllowInjection, SourceRange Range,
+                           ArrayRef<Expr *> Args, Decl *ContainingDecl,
+                           bool RequireScoped) {
   if (!AllowInjection) {
     return Diagnoser(Range.getBegin(),
                      diag::metafn_injected_decl_non_plainly_consteval);
@@ -5952,6 +5962,15 @@ bool define_enum(APValue &Result, ASTContext &C, MetaActions &Meta,
   if (!foundDecl) {
     return DiagnoseReflectionKind(Diagnoser, Range, "an enum type",
                                   DescriptionOf(Scratch));
+  }
+
+  // define_enum only completes scoped enums; define_unscoped_enum only
+  // completes unscoped (C-style) enums.
+  if (foundDecl->isScoped() != RequireScoped) {
+    return Diagnoser(Range.getBegin(),
+                     RequireScoped ? diag::metafn_enum_not_scoped
+                                   : diag::metafn_enum_not_unscoped)
+           << TargetEnum.getAsString();
   }
 
   // Need to check we only have a fwd declare enum
@@ -5996,6 +6015,23 @@ bool define_enum(APValue &Result, ASTContext &C, MetaActions &Meta,
     return true;
   }
   return SetAndSucceed(Result, makeReflection(completedEnum));
+}
+
+bool define_enum(APValue &Result, ASTContext &C, MetaActions &Meta,
+                 EvalFn Evaluator, DiagFn Diagnoser, bool AllowInjection,
+                 QualType ResultTy, SourceRange Range, ArrayRef<Expr *> Args,
+                 Decl *ContainingDecl) {
+  return defineEnumImpl(Result, C, Meta, Evaluator, Diagnoser, AllowInjection,
+                        Range, Args, ContainingDecl, /*RequireScoped=*/true);
+}
+
+bool define_unscoped_enum(APValue &Result, ASTContext &C, MetaActions &Meta,
+                          EvalFn Evaluator, DiagFn Diagnoser,
+                          bool AllowInjection, QualType ResultTy,
+                          SourceRange Range, ArrayRef<Expr *> Args,
+                          Decl *ContainingDecl) {
+  return defineEnumImpl(Result, C, Meta, Evaluator, Diagnoser, AllowInjection,
+                        Range, Args, ContainingDecl, /*RequireScoped=*/false);
 }
 
 bool define_aggregate(APValue &Result, ASTContext &C, MetaActions &Meta,

--- a/libcxx/include/meta
+++ b/libcxx/include/meta
@@ -590,6 +590,9 @@ enum : unsigned {
   // Other bespoke functions (not proposed at this time)
   __metafn_is_access_specified,
   __metafn_reflect_invoke,
+
+  // P4033 extension: completing unscoped (C-style) enums
+  __metafn_define_unscoped_enum,
 };
 
 consteval auto __workaround_expand_compiler_builtins(info type) -> info;
@@ -2386,6 +2389,19 @@ template <reflection_range R = initializer_list<info>>
 consteval auto define_enum(info targetEnum, R&& members) {
   return __metafunction(
     detail::__metafn_define_enum,
+    targetEnum,
+    ranges::size(members),
+    ranges::data(members)
+  );
+}
+
+// Like 'define_enum', but completes an unscoped (C-style) enum instead of a
+// scoped one. Note that, per ordinary unscoped-enum semantics, the resulting
+// enumerators are visible unqualified in the enclosing scope.
+template <reflection_range R = initializer_list<info>>
+consteval auto define_unscoped_enum(info targetEnum, R&& members) {
+  return __metafunction(
+    detail::__metafn_define_unscoped_enum,
     targetEnum,
     ranges::size(members),
     ranges::data(members)

--- a/libcxx/test/std/experimental/reflection/p4033-define-unscoped-enum.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/p4033-define-unscoped-enum.pass.cpp
@@ -1,0 +1,248 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright 2025 Bloomberg Finance L.P.
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03 || c++11 || c++14 || c++17 || c++20
+// ADDITIONAL_COMPILE_FLAGS: -freflection-latest -Wno-deprecated-declarations
+
+#include <meta>
+
+using namespace std::meta;
+
+
+                       // =========================
+                       // basic: simple enumerators
+                       // =========================
+
+namespace basic {
+
+enum Color : int;
+consteval {
+  define_unscoped_enum(^^Color, {
+    enumerator_spec({.name = "Red"}),
+    enumerator_spec({.name = "Green"}),
+    enumerator_spec({.name = "Blue"}),
+  });
+}
+
+static_assert(static_cast<int>(Color::Red) == 0);
+static_assert(static_cast<int>(Color::Green) == 1);
+static_assert(static_cast<int>(Color::Blue) == 2);
+static_assert(is_complete_type(^^Color));
+
+// Unscoped-enum specific: enumerators are visible unqualified in the
+// enclosing scope, and implicitly convert to their underlying type.
+static_assert(Red == Color::Red);
+static_assert(static_cast<int>(Red) == 0);
+constexpr int implicitlyConverted = Green;
+static_assert(implicitlyConverted == 1);
+
+}  // namespace basic
+
+
+                    // ====================
+                    // user-provided values
+                    // ====================
+
+namespace explicit_values {
+
+enum Status : int;
+consteval {
+  define_unscoped_enum(^^Status, {
+    enumerator_spec({.name = "OK",      .value = reflect_constant(0)}),
+    enumerator_spec({.name = "Warning", .value = reflect_constant(10)}),
+    enumerator_spec({.name = "Error",   .value = reflect_constant(20)}),
+  });
+}
+
+static_assert(static_cast<int>(Status::OK) == 0);
+static_assert(static_cast<int>(Status::Warning) == 10);
+static_assert(static_cast<int>(Status::Error) == 20);
+
+}  // namespace explicit_values
+
+
+                   // ============
+                   // mixed_values
+                   // ============
+
+namespace mixed_values {
+
+enum Mixed : int;
+consteval {
+  define_unscoped_enum(^^Mixed, {
+    enumerator_spec({.name = "A"}),                    // 0
+    enumerator_spec({.name = "B"}),                    // 1
+    enumerator_spec({.name = "C", .value = reflect_constant(10)}),     // 10
+    enumerator_spec({.name = "D"}),                    // 11
+  });
+}
+
+static_assert(static_cast<int>(Mixed::A) == 0);
+static_assert(static_cast<int>(Mixed::B) == 1);
+static_assert(static_cast<int>(Mixed::C) == 10);
+static_assert(static_cast<int>(Mixed::D) == 11);
+
+}  // namespace mixed_values
+
+
+                      // =======================
+                      // single_enumerator
+                      // =======================
+
+namespace single_enumerator {
+
+enum Singleton : int;
+consteval {
+  define_unscoped_enum(^^Singleton, {
+    enumerator_spec({.name = "Only"}),
+  });
+}
+
+static_assert(static_cast<int>(Singleton::Only) == 0);
+
+}  // namespace single_enumerator
+
+
+                       // ==========
+                       // empty enum
+                       // ==========
+
+namespace empty_enum {
+
+enum Empty : int;
+consteval {
+  define_unscoped_enum(^^Empty, std::vector<info>{});
+}
+
+static_assert(is_complete_type(^^Empty));
+
+}  // namespace empty_enum
+
+
+                    // ========
+                    // bitflags
+                    // ========
+
+namespace bitflags {
+
+enum Flags : unsigned;
+consteval {
+  define_unscoped_enum(^^Flags, {
+    enumerator_spec({.name = "None",    .value = reflect_constant(0u)}),
+    enumerator_spec({.name = "Read",    .value = reflect_constant(1u)}),
+    enumerator_spec({.name = "Write",   .value = reflect_constant(2u)}),
+    enumerator_spec({.name = "Execute", .value = reflect_constant(4u)}),
+  });
+}
+
+// Unscoped bitflags do not even need a static_cast to combine.
+constexpr unsigned rw = Read | Write;
+static_assert(rw == 3);
+
+}  // namespace bitflags
+
+
+                    // ===================================
+                    // reflect enumerators of defined enum
+                    // ===================================
+
+namespace reflect_after_define {
+
+enum Dir : int;
+consteval {
+  define_unscoped_enum(^^Dir, {
+    enumerator_spec({.name = "North"}),
+    enumerator_spec({.name = "South"}),
+    enumerator_spec({.name = "East"}),
+    enumerator_spec({.name = "West"}),
+  });
+}
+
+static_assert(is_enumerator(^^Dir::North));
+static_assert(is_enumerator(^^Dir::West));
+static_assert(is_type(^^Dir));
+static_assert(!is_scoped_enum_type(^^Dir));
+static_assert(enumerators_of(^^Dir).size() == 4);
+static_assert(identifier_of(^^Dir::East) == "East");
+
+}  // namespace reflect_after_define
+
+
+              // ========================================
+              // templated: define_unscoped_enum inside a
+              // class template
+              // ========================================
+
+namespace templated {
+
+template <typename T>
+struct Holder {
+  enum kind : int;
+  consteval {
+    define_unscoped_enum(^^kind, {
+      enumerator_spec({.name = "First"}),
+      enumerator_spec({.name = "Second"}),
+    });
+  }
+};
+
+// Each instantiation gets its own independent enum.
+using H1 = Holder<int>;
+using H2 = Holder<float>;
+
+static_assert(static_cast<int>(H1::kind::First) == 0);
+static_assert(static_cast<int>(H1::kind::Second) == 1);
+static_assert(static_cast<int>(H2::kind::First) == 0);
+static_assert(static_cast<int>(H2::kind::Second) == 1);
+
+// Unscoped member enum: enumerators are also visible directly through the
+// enclosing class, without going through the enum's own name.
+static_assert(static_cast<int>(H1::First) == 0);
+static_assert(static_cast<int>(H1::Second) == 1);
+
+}  // namespace templated
+
+
+                 // =============
+                 // dynamic_names
+                 // =============
+
+namespace dynamic_names {
+
+struct MessageA {};
+struct MessageB {};
+struct MessageC {};
+
+template <typename... Ts>
+struct Registry {
+  enum kind : int;
+  consteval {
+    std::vector<info> specs;
+    for (auto type : {^^Ts...}) {
+      specs.push_back(enumerator_spec({
+        .name = std::string(identifier_of(type)),
+      }));
+    }
+    define_unscoped_enum(^^kind, specs);
+  }
+};
+
+using R = Registry<MessageA, MessageB, MessageC>;
+
+static_assert(static_cast<int>(R::kind::MessageA) == 0);
+static_assert(static_cast<int>(R::kind::MessageB) == 1);
+static_assert(static_cast<int>(R::kind::MessageC) == 2);
+static_assert(identifier_of(^^R::kind::MessageC) == "MessageC");
+
+}  // namespace dynamic_names
+
+int main() {
+  return 0;
+}

--- a/libcxx/test/std/experimental/reflection/p4033-define-unscoped-enum.verify.cpp
+++ b/libcxx/test/std/experimental/reflection/p4033-define-unscoped-enum.verify.cpp
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright 2025 Bloomberg Finance L.P.
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03 || c++11 || c++14 || c++17 || c++20
+// ADDITIONAL_COMPILE_FLAGS: -freflection-latest -Wno-deprecated-declarations
+
+#include <meta>
+
+using namespace std::meta;
+
+               // ======================================
+               // define_enum rejects an unscoped enum
+               // ======================================
+
+namespace define_enum_rejects_unscoped {
+
+enum PlainEnum : int;
+consteval {  // expected-error {{consteval block must be a constant expression}}
+  define_enum(^^PlainEnum, {  // expected-note {{is not a scoped enumeration type}}
+    enumerator_spec({.name = "A"}),
+  });
+}
+
+}  // namespace define_enum_rejects_unscoped
+
+
+          // ==============================================
+          // define_unscoped_enum rejects a scoped enum
+          // ==============================================
+
+namespace define_unscoped_enum_rejects_scoped {
+
+enum class ScopedEnum : int;
+consteval {  // expected-error {{consteval block must be a constant expression}}
+  define_unscoped_enum(^^ScopedEnum, {  // expected-note {{is not an unscoped enumeration type}}
+    enumerator_spec({.name = "A"}),
+  });
+}
+
+}  // namespace define_unscoped_enum_rejects_scoped
+
+int main() {
+  return 0;
+}


### PR DESCRIPTION

**Describe your changes**
There was already support for unscoped enum synthesis, more by lack of enforcing scoped enum than actual purpose.
This makes it clear by introducing `define_unscoped_enum` which does what it says it does.

**Testing performed**
some (claude-assisted) LIT tests

**Additional context**
this is part of p4033 , likely the R2