### PR TITLE
Add std::meta::has_c_language_linkage

### DIFF
--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -652,6 +652,11 @@ static bool alignment_of(APValue &Result, ASTContext &C, MetaActions &Meta,
                          SourceRange Range, ArrayRef<Expr *> Args,
                          Decl *ContainingDecl);
 
+static bool has_c_language_linkage(APValue &Result, ASTContext &C, MetaActions &Meta,
+                                   EvalFn Evaluator, DiagFn Diagnoser, bool AllowInjection,
+                                   QualType ResultTy, SourceRange Range,
+                                   ArrayRef<Expr *> Args, Decl *ContainingDecl);
+
 // -----------------------------------------------------------------------------
 // P3096 Metafunction declarations
 // -----------------------------------------------------------------------------
@@ -926,6 +931,7 @@ static constexpr Metafunction Metafunctions[] = {
   { Metafunction::MFRK_spliceFromArg, 2, 2, bit_offset_of },
   { Metafunction::MFRK_sizeT, 1, 1, bit_size_of },
   { Metafunction::MFRK_sizeT, 1, 1, alignment_of },
+  { Metafunction::MFRK_bool, 1, 1, has_c_language_linkage },
 
   // P3096 metafunction extensions
   { Metafunction::MFRK_metaInfo, 3, 3, get_ith_parameter_of },
@@ -6384,6 +6390,29 @@ bool alignment_of(APValue &Result, ASTContext &C, MetaActions &Meta,
         << 4 << DescriptionOf(RV) << Range;
   }
   llvm_unreachable("unknown reflection kind");
+}
+
+bool has_c_language_linkage(APValue &Result, ASTContext &C, MetaActions &Meta,
+                            EvalFn Evaluator, DiagFn Diagnoser, bool AllowInjection,
+                            QualType ResultTy, SourceRange Range, ArrayRef<Expr *> Args,
+                            Decl *ContainingDecl) {
+  assert(Args[0]->getType()->isReflectionType());
+  assert(ResultTy == C.BoolTy);
+
+  APValue RV;
+  if (!Evaluator(RV, Args[0], true))
+    return true;
+
+  bool result = false;
+  if (RV.isReflectedDecl()) {
+    if (const Decl *D = RV.getReflectedDecl()) {
+      if (const auto *FD = dyn_cast<FunctionDecl>(D))
+        result = FD->isExternC();
+      else if (const auto *VD = dyn_cast<VarDecl>(D))
+        result = VD->isExternC();
+    }
+  }
+  return SetAndSucceed(Result, makeBool(C, result));
 }
 
 bool get_ith_parameter_of(APValue &Result, ASTContext &C, MetaActions &Meta,

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -6411,6 +6411,19 @@ bool has_c_language_linkage(APValue &Result, ASTContext &C, MetaActions &Meta,
       else if (const auto *VD = dyn_cast<VarDecl>(D))
         result = VD->isExternC();
     }
+  } else if (RV.isReflectedType())  {
+    const auto QT = RV.getReflectedType();
+    if (const auto *TT = QT->getAs<clang::TypedefType>())
+      if (TT->isFunctionType() || TT->desugar()->isFunctionType()) {
+        if (const clang::TypedefNameDecl *TD = TT->getDecl()) {
+           for (const clang::DeclContext *DC = TD->getDeclContext();
+                DC; DC = DC->getParent())
+             if (const auto *LSD = llvm::dyn_cast<clang::LinkageSpecDecl>(DC)) {
+               result = (LSD->getLanguage() == clang::LinkageSpecLanguageIDs::C);
+               break;
+             }
+        }
+      }
   }
   return SetAndSucceed(Result, makeBool(C, result));
 }

--- a/libcxx/include/meta
+++ b/libcxx/include/meta
@@ -560,6 +560,7 @@ enum : unsigned {
   __metafn_bit_offset_of,
   __metafn_bit_size_of,
   __metafn_alignment_of,
+  __metafn_has_c_language_linkage,
 
   // P3096 parameter reflection metafunctions
   __metafn_get_ith_parameter_of,
@@ -2357,6 +2358,11 @@ struct data_member_options {
 // Returns the alignment of the reflected entity.
 consteval auto alignment_of(info r) -> size_t {
   return __metafunction(detail::__metafn_alignment_of, r);
+}
+
+// Returns whether the reflected entity (either a function or a variable) has C language linkage.
+consteval auto has_c_language_linkage(info r) -> bool {
+  return __metafunction(detail::__metafn_has_c_language_linkage, r);
 }
 
 struct enumerator_options {

--- a/libcxx/test/std/experimental/reflection/linkage-and-storage-class.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/linkage-and-storage-class.pass.cpp
@@ -296,11 +296,17 @@ extern "C" {
 void c_fun(int);
 int c_var;
 typedef void tdef_fun(void*);
+using alias_fun = void*(int);
+typedef char *pchr;
+using pdbl = double*;
 }
 
 static_assert(has_c_language_linkage(^^c_fun));
 static_assert(has_c_language_linkage(^^c_var));
-static_assert(!has_c_language_linkage(^^tdef_fun));
+static_assert(has_c_language_linkage(^^tdef_fun));
+static_assert(has_c_language_linkage(^^alias_fun));
+static_assert(!has_c_language_linkage(^^pchr));
+static_assert(!has_c_language_linkage(^^pdbl));
 
 extern "C" void other_c_fun(int);
 

--- a/libcxx/test/std/experimental/reflection/linkage-and-storage-class.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/linkage-and-storage-class.pass.cpp
@@ -258,6 +258,94 @@ static_assert(!has_external_linkage(^^TFn));
 static_assert(!has_external_linkage(^^TVar));
 }  // namespace linkage
 
+                              // ====================
+                              // c_language_linkage
+                              // ====================
+
+namespace c_language_linkage {
+
+int cxx_var;
+void cxx_fn(int);
+struct S { void mem_fn(unsigned); };
+using cxx_fn_type = void(int);
+struct S2 {
+    int var;
+    void fun();   
+} vs2;
+S2& vs2_ref = vs2;
+static_assert(!has_c_language_linkage(^^cxx_var));
+static_assert(!has_c_language_linkage(^^cxx_fn));
+static_assert(!has_c_language_linkage(^^S));
+static_assert(!has_c_language_linkage(^^S::mem_fn));
+static_assert(!has_c_language_linkage(^^cxx_fn_type));
+static_assert(!has_c_language_linkage(^^S2));
+static_assert(!has_c_language_linkage(^^S2::var));
+static_assert(!has_c_language_linkage(^^S2::fun));
+static_assert(!has_c_language_linkage(^^vs2));
+static_assert(!has_c_language_linkage(^^vs2_ref));
+
+template <typename T> struct TCls;
+template <typename T> void TFn();
+template <typename T> int TVar;
+
+static_assert(!has_c_language_linkage(^^TCls));
+static_assert(!has_c_language_linkage(^^TFn));
+static_assert(!has_c_language_linkage(^^TVar));
+
+extern "C" {
+void c_fun(int);
+int c_var;
+typedef void tdef_fun(void*);
+}
+
+static_assert(has_c_language_linkage(^^c_fun));
+static_assert(has_c_language_linkage(^^c_var));
+static_assert(!has_c_language_linkage(^^tdef_fun));
+
+extern "C" void other_c_fun(int);
+
+static_assert(has_c_language_linkage(^^other_c_fun));
+
+extern "C" {
+static void fs() {}
+}
+
+static_assert(!has_c_language_linkage(^^fs));
+static_assert(!has_c_language_linkage(type_of(^^fs)));
+static_assert(has_internal_linkage(^^fs));
+
+extern "C" {
+namespace { void inner_c_fun() {} }
+}
+
+static_assert(has_c_language_linkage(^^inner_c_fun));
+
+extern "C" {
+extern "C++" {
+void cxx_fun_extern(int);
+}
+}
+
+static_assert(!has_c_language_linkage(^^cxx_fun_extern));
+
+namespace inner_ns { 
+void inner_fun();
+int inner_var;
+}
+namespace inner_ns_alias = inner_ns;
+
+static_assert(!has_c_language_linkage(^^inner_ns));
+static_assert(!has_c_language_linkage(^^inner_ns::inner_fun));
+static_assert(!has_c_language_linkage(^^inner_ns::inner_var));
+static_assert(!has_c_language_linkage(^^inner_ns_alias));
+
+extern "C" {
+struct CCls { void mem_fn(int); };
+}
+
+static_assert(!has_c_language_linkage(^^CCls::mem_fn));
+}  // namespace c_language_linkage
+
 export module test_module;
 namespace linkage {
 int module_global;


### PR DESCRIPTION
Provisionally adding `std::meta::has_c_language_linkage` which is now standard in C++26 (and perhaps could be useful for a header-file implementation of `has_parent`?)

**Testing**
Updated `linkage-and-storage-class.pass.cpp` (most obvious place for this, I think) accordingly. All passing.

**Notes**
Of potential concern: ` extern "C" { static void f() {} } `  `^^f` will be seen and having internal linkage and *not* C language linkage. For reference, it looks like GCC 16's opinion differs in that regard. 
