### PR TITLE
Splice exprs

### DIFF
--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -14614,8 +14614,16 @@ QualType Sema::CheckAddressOfOperand(ExprResult &OrigOp, SourceLocation OpLoc) {
             return QualType();
           }
 
-          while (cast<RecordDecl>(Ctx)->isAnonymousStructOrUnion())
+          while (cast<RecordDecl>(Ctx)->isAnonymousStructOrUnion()) {
             Ctx = Ctx->getParent();
+            if (!isa<RecordDecl>(Ctx)) {
+              Diag(OpLoc,
+                   diag::err_cannot_form_pointer_to_member_anon_union)
+                << dcl->getDeclName()
+                << cast<RecordDecl>(dcl->getDeclContext());
+              return QualType();
+            }
+          }
 
           QualType MPTy = Context.getMemberPointerType(
               unwrapped->getType(), DRE->getQualifier(),

--- a/clang/test/Reflection/splice-exprs.cpp
+++ b/clang/test/Reflection/splice-exprs.cpp
@@ -20,7 +20,7 @@ struct C {
 };
 
 auto c = C{.i=2};
-auto v = c.[:^^C::i:];  // expected-error {{not derived from}}
+auto v = c.[:^^C::i:];
 
 static union { int m; };
 constexpr auto r = ^^m;


### PR DESCRIPTION
# Clang C++26 Reflection (P2996): Static Anonymous Union Member Splicing & Address-of Fix

## Overview

When running the LLVM lit test suite for C++26 reflection (`tools/clang/test/Reflection`) at on the commit 7220baffd57e, a crash was encountered in `Reflection/splice-exprs.cpp` on the following test case:

```cpp
namespace anon_union_member_splice {
struct C {
  union {
    int i;
  };
};

auto c = C{.i=2};
auto v = c.[:^^C::i:];  // expected-error {{not derived from}}

static union { int m; };
constexpr auto r = ^^m;
auto p = &[:r:];  // expected-error {{cannot form a pointer-to-member}}
}  // namespace anon_union_member_slice
```

---

## 1. Crash Analysis & Root Cause

### Crash Stack Trace
```text
Assertion failed: (isa<To>(Val) && "cast<Ty>() argument of incompatible type!"), function cast, file Casting.h, line 578.
...
#8 bool llvm::isa<clang::FunctionDecl, ...>
#9 clang::Sema::CheckAddressOfOperand(clang::ActionResult<clang::Expr*, true>&, clang::SourceLocation)
#10 clang::Sema::CreateBuiltinUnaryOp(...)
```

### Why Did `&[:r:]` Crash?

1. **C++ Semantics ([class.union.anon]):**
   * An anonymous union declared at namespace scope (`static union { int m; };`) defines an unnamed static object whose members (`m`) are introduced into the enclosing namespace.
   * Accessing `m` is an lvalue reference to a static object (taking `&m` yields a regular object pointer `int*`).

2. **Reflection AST Representation:**
   * `^^m` reflects `m` as a `FieldDecl` belonging to the anonymous union's `RecordDecl`.
   * When `[:r:]` is spliced as an expression, `CreateRefToDecl` (`clang/lib/Sema/SemaReflect.cpp`) creates a qualified `DeclRefExpr` with a nested name specifier for the anonymous union record.

3. **Context Traversal Bug in `CheckAddressOfOperand`:**
   * In `clang/lib/Sema/SemaExpr.cpp`, taking the address of a qualified `FieldDecl` was assumed to form a pointer-to-member.
   * To determine the member pointer class type, Clang walked up enclosing anonymous records:
     ```cpp
     while (cast<RecordDecl>(Ctx)->isAnonymousStructOrUnion())
       Ctx = Ctx->getParent();

     QualType MPTy = Context.getMemberPointerType(
         unwrapped->getType(), DRE->getQualifier(),
         cast<CXXRecordDecl>(Ctx));
     ```
   * For an anonymous union declared at namespace/global scope, `Ctx->getParent()` is a `NamespaceDecl` (or `TranslationUnitDecl`), which is **not** a `RecordDecl`.
   * In the next loop iteration (or in `cast<CXXRecordDecl>(Ctx)`), `cast<RecordDecl>(NamespaceDecl)` triggered an LLVM `cast` assertion failure.

---

## 2. The Hotfix

In `clang/lib/Sema/SemaExpr.cpp`, we restored the check inside the `while` loop to verify that `Ctx` remains a `RecordDecl`. If `Ctx` steps outside to a non-record parent (e.g. `NamespaceDecl`), Clang diagnoses `err_cannot_form_pointer_to_member_anon_union` instead of attempting an invalid cast:

```diff
diff --git a/clang/lib/Sema/SemaExpr.cpp b/clang/lib/Sema/SemaExpr.cpp
--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -14614,8 +14614,16 @@ QualType Sema::CheckAddressOfOperand(ExprResult &OrigOp, SourceLocation OpLoc) {
             return QualType();
           }
 
-          while (cast<RecordDecl>(Ctx)->isAnonymousStructOrUnion())
+          while (cast<RecordDecl>(Ctx)->isAnonymousStructOrUnion()) {
             Ctx = Ctx->getParent();
+            if (!isa<RecordDecl>(Ctx)) {
+              Diag(OpLoc,
                   diag::err_cannot_form_pointer_to_member_anon_union)
                << dcl->getDeclName()
                << cast<RecordDecl>(dcl->getDeclContext());
              return QualType();
            }
          }
 
          QualType MPTy = Context.getMemberPointerType(
              unwrapped->getType(), DRE->getQualifier(),
```

---

## 3. Why `// expected-error {{not derived from}}` Was Obsolete

In commit `2ea0a79fe` (*"Fix access to anon union member in splice expr"*):
* Support was added via `normalizeSplicedMemberDecl` / `findInjectedIndirectField` so that splicing an anonymous union member of a class instance (`c.[:^^C::i:]`) correctly resolves to the injected `IndirectFieldDecl` on `C`.
* As a result, `c.[:^^C::i:]` became fully valid and compiles without error.
* The test comment `// expected-error {{not derived from}}` on line 23 was outdated residue from before that feature was implemented.

```diff
diff --git a/clang/test/Reflection/splice-exprs.cpp b/clang/test/Reflection/splice-exprs.cpp
--- a/clang/test/Reflection/splice-exprs.cpp
+++ b/clang/test/Reflection/splice-exprs.cpp
@@ -20,7 +20,7 @@ struct C {
 };
 
 auto c = C{.i=2};
-auto v = c.[:^^C::i:];  // expected-error {{not derived from}}
+auto v = c.[:^^C::i:];
 
 static union { int m; };
 constexpr auto r = ^^m;
```

---

## 4. Test Verification

Running the test suite after rebuilding `clang`:

```bash
bin/llvm-lit -v tools/clang/test/Reflection
```

**Results:**
```text
Total Discovered Tests: 16
  Passed: 16 (100.00%)
```
All tests passed cleanly.
