### PR TITLE
Remediation to a couple of bugs in implementation

### DIFF
--- a/clang/include/clang/AST/APValue.h
+++ b/clang/include/clang/AST/APValue.h
@@ -486,6 +486,18 @@ public:
     Result.Kind = Indeterminate;
     return Result;
   }
+  /// The greatest value representable by the reflection-depth counter, and
+  /// therefore the deepest reflection-of-a-reflection this representation can
+  /// hold.
+  static constexpr unsigned MaxReflectionDepth = 255;
+
+  /// Whether 'Lift' can be applied without exceeding 'MaxReflectionDepth'.
+  ///
+  /// Callers that can be handed a user-controlled 'std::meta::info' must check
+  /// this and diagnose; 'Lift' itself has no channel through which to report
+  /// the failure and returns a value of kind 'None'.
+  bool canLift() const { return ReflectionDepth < MaxReflectionDepth; }
+
   APValue Lift(QualType ResultType) const;
   APValue Lower() const;
 

--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -61,6 +61,7 @@ class APValue;
 class ASTMutationListener;
 class ASTRecordLayout;
 class AtomicExpr;
+struct AttributeScratchpad;
 class BlockExpr;
 struct BlockVarCopyInit;
 class BuiltinTemplateDecl;
@@ -744,6 +745,10 @@ private:
   std::unique_ptr<interp::Context> InterpContext;
   std::unique_ptr<ParentMapContext> ParentMapCtx;
 
+  /// Storage for the ParsedAttrs synthesized by attribute reflection.
+  /// Created on first use; see getAttributeScratchpad().
+  std::unique_ptr<AttributeScratchpad> AttrScratchpad;
+
   /// Keeps track of the deallocated DeclListNodes for future reuse.
   DeclListNode *ListNodeFreeList = nullptr;
 
@@ -758,6 +763,13 @@ public:
 
   /// Returns the clang bytecode interpreter context.
   interp::Context &getInterpContext();
+
+  /// Returns this context's storage for ParsedAttrs synthesized by the
+  /// attribute reflection metafunctions, creating it on first use.
+  ///
+  /// The scratchpad is per-ASTContext rather than global: its allocator is
+  /// not thread-safe, and the attributes it owns point into this context.
+  AttributeScratchpad &getAttributeScratchpad();
 
   struct CUDAConstantEvalContext {
     /// Do not allow wrong-sided variables in constant expressions.

--- a/clang/include/clang/AST/ExprCXX.h
+++ b/clang/include/clang/AST/ExprCXX.h
@@ -5547,8 +5547,9 @@ private:
   unsigned MetaFnID;
 
   // An unowned reference to a callback for executing the metafunction at
-  // constant evaluation time.
-  const ImplFn *Impl;
+  // constant evaluation time. Null until deserialization supplies one, and
+  // left null if the serialized metafunction ID names nothing.
+  const ImplFn *Impl = nullptr;
 
   // Result type.
   QualType ResultType;
@@ -5583,8 +5584,15 @@ public:
   unsigned getMetaFnID() const { return MetaFnID; }
   void setMetaFnID(unsigned ID) { MetaFnID = ID; }
 
-  const ImplFn &getImpl() const { return *Impl; }
-  void setImpl(const ImplFn &Fn) { Impl = &Fn; }
+  /// Whether an evaluation callback is attached. False only for an expression
+  /// read back from a malformed AST file naming an unknown metafunction.
+  bool hasImpl() const { return Impl != nullptr; }
+
+  const ImplFn &getImpl() const {
+    assert(Impl && "no metafunction implementation");
+    return *Impl;
+  }
+  void setImpl(const ImplFn *Fn) { Impl = Fn; }
 
   QualType getResultType() const { return ResultType; }
   void setResultType(QualType QT) { ResultType = QT; }

--- a/clang/include/clang/Basic/DiagnosticMetafnKinds.td
+++ b/clang/include/clang/Basic/DiagnosticMetafnKinds.td
@@ -100,6 +100,8 @@ def metafn_value_not_structural_type : Note<
   "values of non-structural type %0 cannot be represented as reflections">;
 def metafn_result_not_representable : Note<
   "provided %select{value|object}0 cannot be represented by a reflection">;
+def metafn_reflection_depth_exceeded : Note<
+  "reflection would nest more than %0 levels deep">;
 
 def metafn_p3385_non_standard_attribute : Warning<
   "non-standard attribute %0 found when expanding attributes">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -3205,6 +3205,8 @@ def err_reflect_local_requires_param : Error<
 def err_reflect_intervening_lambda : Error<
   "cannot take the reflection of a local entity for which there is an "
   "intervening lambda expression">;
+def err_reflection_depth_exceeded : Error<
+  "reflection would nest more than %0 levels deep">;
 
 def err_splice_operand_not_reflection : Error<
   "splice operand must be a reflection">;

--- a/clang/include/clang/Sema/ParsedAttr.h
+++ b/clang/include/clang/Sema/ParsedAttr.h
@@ -724,6 +724,9 @@ public:
 
   AttributeFactory &getFactory() const { return Factory; }
 
+  /// The number of attributes currently owned by this pool.
+  size_t size() const { return Attrs.size(); }
+
   void clear() {
     Factory.reclaimPool(*this);
     Attrs.clear();

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -15689,7 +15689,10 @@ public:
 
   DeclContext *TryFindDeclContextOf(SpliceSpecifier *Splice);
 
-  const CXXMetafunctionExpr::ImplFn &getMetafunctionCb(unsigned FnID);
+  /// Returns the evaluation callback for the metafunction with the given ID,
+  /// or null if no such metafunction exists. IDs can arrive from a serialized
+  /// AST, so callers must handle the null result rather than assume validity.
+  const CXXMetafunctionExpr::ImplFn *getMetafunctionCb(unsigned FnID);
 
   static IndirectFieldDecl *findInjectedIndirectField(CXXRecordDecl *Outer,
                                                       FieldDecl *FD) {

--- a/clang/include/clang/Serialization/ASTRecordReader.h
+++ b/clang/include/clang/Serialization/ASTRecordReader.h
@@ -371,8 +371,23 @@ public:
 
   /// P2996 hack: Use the 'Sema' object from the ASTReader to get a
   /// metafunction callback during deserialization of a CXXMetafunctionExpr.
-  const CXXMetafunctionExpr::ImplFn &getMetafunctionCb(unsigned ID) {
-    return Reader->getSema()->getMetafunctionCb(ID);
+  ///
+  /// The ID is read verbatim from the AST file, so it is untrusted. Returns
+  /// null (having reported the file as malformed) if it names no metafunction,
+  /// or if the reader has no 'Sema' to ask.
+  const CXXMetafunctionExpr::ImplFn *getMetafunctionCb(unsigned ID) {
+    Sema *S = Reader->getSema();
+    if (!S) {
+      Reader->Error("metafunction expression deserialized without a Sema "
+                    "object");
+      return nullptr;
+    }
+
+    const CXXMetafunctionExpr::ImplFn *Impl = S->getMetafunctionCb(ID);
+    if (!Impl)
+      Reader->Error("malformed metafunction ID in AST file");
+
+    return Impl;
   }
 };
 

--- a/clang/lib/AST/APValue.cpp
+++ b/clang/lib/AST/APValue.cpp
@@ -907,9 +907,22 @@ ReflectionKind APValue::getReflectionKind() const {
   }
 }
 
+static_assert(APValue::MaxReflectionDepth ==
+                  std::numeric_limits<uint8_t>::max(),
+              "MaxReflectionDepth must match the width of ReflectionDepth");
+
 APValue APValue::Lift(QualType ResultType) const {
-  assert(ReflectionDepth <
-         std::numeric_limits<decltype(ReflectionDepth)>::max());
+  // Refuse to wrap the depth counter. A wrapped counter would take a value
+  // whose static type is 'std::meta::info' back down to depth zero, where
+  // 'isReflection()' is false and 'getReflectionKind()' reads the raw union
+  // bytes of the underlying value as a 'ReflectionData' -- a kind
+  // discriminant and an entity pointer that accessors then dereference.
+  //
+  // There is no way to report the failure from here; callers that can be
+  // handed a user-controlled reflection must check 'canLift()' first and
+  // diagnose. Returning 'None' keeps the wrap unreachable for any that do not.
+  if (!canLift())
+    return APValue();
 
   // TODO: Special case for lvalues referring to functions?
   //       Should be "promoted" to a reflection of the function declaration.

--- a/clang/lib/AST/APValue.cpp
+++ b/clang/lib/AST/APValue.cpp
@@ -774,6 +774,62 @@ QualType APValue::getTypeOfReflectedResult(const ASTContext &C) const {
   return C.MetaInfoTy;
 }
 
+/// Computes the type of the subobject designated by an lvalue.
+///
+/// 'LValuePathEntry' is an untagged union: an entry is a base-or-member
+/// declaration only when the type it is applied to is a class type, and is a
+/// raw index otherwise. The path must therefore be walked from the base type
+/// forwards, discriminating each entry by the type reached so far; decoding an
+/// array index as a 'Decl *' would dereference an arbitrary address.
+///
+/// Returns a null 'QualType' if the path can not be walked.
+///
+/// 'V' must have 'LValue' representation; note that this is not the same as
+/// 'V.isLValue()', which is additionally false once a value has been lifted
+/// into a reflection. The lvalue accessors below assert on the representation.
+static QualType ComputeLValueType(const APValue &V) {
+  if (V.getLValueBase().isNull())
+    return QualType {};
+
+  QualType BaseTy = V.getLValueBase().getType();
+  if (BaseTy.isNull())
+    return QualType {};
+
+  SplitQualType SQT = BaseTy.split();
+  if (!V.hasLValuePath())
+    return QualType(SQT.Ty, SQT.Quals.getAsOpaqueValue());
+
+  auto StepTo = [&SQT](QualType QT) {
+    SQT.Ty = QT.getTypePtr();
+    if (QT.isConstQualified()) SQT.Quals.addConst();
+    if (QT.isVolatileQualified()) SQT.Quals.addVolatile();
+  };
+
+  for (const APValue::LValuePathEntry &E : V.getLValuePath()) {
+    if (SQT.Ty->isRecordType()) {
+      // The entry designates a base class or a non-static data member.
+      const Decl *D = E.getAsBaseOrMember().getPointer();
+      if (const auto *FD = dyn_cast_or_null<FieldDecl>(D))
+        StepTo(FD->getType());
+      else if (const auto *RD = dyn_cast_or_null<CXXRecordDecl>(D))
+        SQT.Ty = RD->getTypeForDecl();
+      else
+        return QualType {};
+    } else if (SQT.Ty->isAnyComplexType()) {
+      // The entry is the index of the real or imaginary part.
+      StepTo(SQT.Ty->castAs<ComplexType>()->getElementType());
+    } else if (const auto *AT = SQT.Ty->getAsArrayTypeUnsafe()) {
+      // The entry is an array index.
+      StepTo(AT->getElementType());
+    } else {
+      // The path does not match the type of the base; give up rather than
+      // reinterpret the entry as something it is not.
+      return QualType {};
+    }
+  }
+  return QualType(SQT.Ty, SQT.Quals.getAsOpaqueValue());
+}
+
 ReflectionKind APValue::getReflectionKind() const {
   assert(isReflection() && "not a reflection value");
 
@@ -817,16 +873,11 @@ ReflectionKind APValue::getReflectionKind() const {
         //   (normalized) type is the same as its 'UnderlyingTy'.
         const Type *LVTy = nullptr;
 
-        // If we have an LValuePath, use the type of the back-most path element.
+        // If we have an LValuePath, use the type of the designated subobject.
         if (hasLValuePath() && getLValuePath().size() > 0) {
-          const LValuePathEntry &E = getLValuePath().back();
-          if (const auto *D = E.getAsBaseOrMember().getPointer()) {
-            if (auto *FD = dyn_cast<FieldDecl>(D))
-              LVTy = FD->getType()->getCanonicalTypeUnqualified().getTypePtr();
-            else if (auto *TD = dyn_cast<CXXRecordDecl>(D))
-              LVTy = TD->getTypeForDecl()
-                        ->getCanonicalTypeUnqualified().getTypePtr();
-          }
+          QualType QT = ComputeLValueType(*this);
+          if (!QT.isNull())
+            LVTy = QT->getCanonicalTypeUnqualified().getTypePtr();
         }
 
         // Otherwise, infer from the LValueBase.
@@ -854,41 +905,6 @@ ReflectionKind APValue::getReflectionKind() const {
       // a value; the type is 'std::meta::info'.
       return ReflectionKind::Value;
   }
-}
-
-static QualType ComputeLValueType(const APValue &V) {
-  assert(V.isLValue());
-  if (V.getLValueBase().isNull())
-    return QualType {};
-
-  SplitQualType SQT = V.getLValueBase().getType().split();
-
-  for (auto p = V.getLValuePath().begin();
-       p != V.getLValuePath().end(); ++p) {
-    const Decl *D = V.getLValuePath().back().getAsBaseOrMember().getPointer();
-    if (D) {  // base or member case
-      if (auto *VD = dyn_cast<FieldDecl>(D)) {
-        QualType QT = VD->getType();
-        SQT.Ty = QT.getTypePtr();
-
-        if (QT.isConstQualified()) SQT.Quals.addConst();
-        if (QT.isVolatileQualified()) SQT.Quals.addVolatile();
-
-        continue;
-      } else if (auto *TD = dyn_cast<CXXRecordDecl>(D)) {
-        SQT.Ty = TD->getTypeForDecl();
-        continue;
-      }
-
-      llvm_unreachable("unknown lvalue path kind");
-    } else { // array case
-      QualType QT = cast<ArrayType>(SQT.Ty)->getElementType();
-      SQT.Ty = QT.getTypePtr();
-      if (QT.isConstQualified()) SQT.Quals.addConst();
-      if (QT.isVolatileQualified()) SQT.Quals.addVolatile();
-    }
-  }
-  return QualType(SQT.Ty, SQT.Quals.getAsOpaqueValue());
 }
 
 APValue APValue::Lift(QualType ResultType) const {

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/AST/ASTContext.h"
+#include "AttributeScratchpad.h"
 #include "ByteCode/Context.h"
 #include "CXXABI.h"
 #include "clang/AST/APValue.h"
@@ -912,6 +913,12 @@ interp::Context &ASTContext::getInterpContext() {
     InterpContext.reset(new interp::Context(*this));
   }
   return *InterpContext;
+}
+
+AttributeScratchpad &ASTContext::getAttributeScratchpad() {
+  if (!AttrScratchpad)
+    AttrScratchpad = std::make_unique<AttributeScratchpad>();
+  return *AttrScratchpad;
 }
 
 ParentMapContext &ASTContext::getParentMapContext() {

--- a/clang/lib/AST/AttributeScratchpad.h
+++ b/clang/lib/AST/AttributeScratchpad.h
@@ -1,0 +1,37 @@
+//===- AttributeScratchpad.h - Synthesized ParsedAttr storage ---*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Defines the storage used by the P3385 attribute reflection metafunctions to
+// hold the ParsedAttr nodes they synthesize from semantic Attrs.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_LIB_AST_ATTRIBUTESCRATCHPAD_H
+#define LLVM_CLANG_LIB_AST_ATTRIBUTESCRATCHPAD_H
+
+#include "clang/Sema/ParsedAttr.h"
+
+namespace clang {
+
+/// Owns the ParsedAttr nodes synthesized while evaluating attribute
+/// reflection metafunctions.
+///
+/// Neither AttributeFactory nor AttributePool is thread-safe, and the
+/// ParsedAttrs handed out here embed pointers (Exprs, IdentifierInfos) into
+/// the ASTContext that produced them. One scratchpad therefore belongs to one
+/// ASTContext, which owns it and destroys it along with the AST that refers
+/// to those attributes; see ASTContext::getAttributeScratchpad().
+struct AttributeScratchpad {
+  AttributeFactory factory;
+  AttributePool pool;
+  AttributeScratchpad() : factory(), pool(factory) {}
+};
+
+} // namespace clang
+
+#endif // LLVM_CLANG_LIB_AST_ATTRIBUTESCRATCHPAD_H

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -8894,6 +8894,11 @@ bool ExprEvaluatorBase<Derived>::VisitCXXMetafunctionExpr(
       (Info.EvalMode ==
        EvalInfo::EM_ConstantExpressionPlainlyConstantEvaluated);
 
+  // An expression deserialized from a malformed AST file may name no
+  // metafunction at all; the reader has already diagnosed the file.
+  if (!E->hasImpl())
+    return Error(E);
+
   // Evaluate the metafunction.
   APValue Result;
   const CXXMetafunctionExpr::ImplFn &Implementation = E->getImpl();

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "AttributeScratchpad.h"
 #include "clang/AST/APValue.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Attr.h"
@@ -1864,12 +1865,6 @@ llvm::SmallVector<const Attr*, 8> static collectUniqueCxx11Attrs(const Decl *D) 
   return Result;
 }
 
-struct AttributeScratchpad {
-  AttributeFactory factory;
-  AttributePool pool;
-  AttributeScratchpad() : factory(), pool(factory) {}
-};
-
 // -----------------------------------------------------------------------------
 // Metafunction implementations
 // -----------------------------------------------------------------------------
@@ -2036,7 +2031,9 @@ bool is_msvc_attribute(APValue &Result, ASTContext &C,
 // Synthesize back a ParsedAttr from an Attr, the best I can...
 // Return a nullptr if the process met an error
 static const ParsedAttr* toSyntacticForm(const Attr* val, ASTContext * C) {
-  static AttributeScratchpad scratchpad;
+  // Owned by the ASTContext: the pool's allocator is not thread-safe, and the
+  // ParsedAttrs built below point back into this context.
+  AttributeScratchpad &scratchpad = C->getAttributeScratchpad();
   ParsedAttr * recoveredAttr = nullptr;
   auto onArgs = [&](
       IdentifierInfo * attrName,

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -1050,6 +1050,22 @@ static bool SetAndSucceed(APValue &Out, const APValue &Result) {
   return false;
 }
 
+/// Lifts 'V' into a reflection and stores it in 'Out'.
+///
+/// The reflection-depth counter is a fixed-width field, and 'std::meta::info'
+/// is itself a structural type, so a metafunction handed a reflection can be
+/// asked to reflect it again without bound. Diagnose at the limit rather than
+/// letting 'APValue::Lift' silently produce a value of kind 'None'.
+static bool SetAndSucceedWithLift(APValue &Out, DiagFn Diagnoser,
+                                  SourceRange Range, const APValue &V,
+                                  QualType ResultTy) {
+  if (!V.canLift())
+    return Diagnoser(Range.getBegin(), diag::metafn_reflection_depth_exceeded)
+        << APValue::MaxReflectionDepth << Range;
+
+  return SetAndSucceed(Out, V.Lift(ResultTy));
+}
+
 static TemplateName findTemplateOfDecl(const Decl *D) {
   TemplateDecl *TDecl = nullptr;
   if (const auto *FD = dyn_cast<FunctionDecl>(D)) {
@@ -3276,7 +3292,8 @@ bool constant_of(APValue &Result, ASTContext &C, MetaActions &Meta,
                     false);
       ConstantTy = QualType{};
     }
-    return SetAndSucceed(Result, Constant.Lift(ConstantTy));
+    return SetAndSucceedWithLift(Result, Diagnoser, Range, Constant,
+                                 ConstantTy);
   }
   case ReflectionKind::Declaration: {
     ValueDecl *Decl = RV.getReflectedDecl();
@@ -3326,7 +3343,8 @@ bool constant_of(APValue &Result, ASTContext &C, MetaActions &Meta,
       ConstantTy = QualType{};
     }
 
-    return SetAndSucceed(Result, Constant.Lift(ConstantTy));
+    return SetAndSucceedWithLift(Result, Diagnoser, Range, Constant,
+                                 ConstantTy);
   }
   case ReflectionKind::Annotation: {
     CXX26AnnotationAttr *A = RV.getReflectedAnnotation();
@@ -3341,7 +3359,8 @@ bool constant_of(APValue &Result, ASTContext &C, MetaActions &Meta,
                     false);
       ConstantTy = QualType{};
     }
-    return SetAndSucceed(Result, Constant.Lift(ConstantTy));
+    return SetAndSucceedWithLift(Result, Diagnoser, Range, Constant,
+                                 ConstantTy);
   }
   case ReflectionKind::Attribute: // TODO P3385 anything to do ?
   case ReflectionKind::Null:
@@ -5625,6 +5644,14 @@ bool reflect_result(APValue &Result, ASTContext &C, MetaActions &Meta,
   if (!Evaluator(Arg, Args[1], !IsLValue))
     return true;
 
+  // 'std::meta::info' is a structural type, so 'reflect_constant' accepts a
+  // reflection and yields a reflection of it. Nothing else caps how many times
+  // that can be repeated, so check here before the depth counter would
+  // overflow.
+  if (!Arg.canLift())
+    return Diagnoser(Range.getBegin(), diag::metafn_reflection_depth_exceeded)
+        << APValue::MaxReflectionDepth << Range;
+
   // Construct an expression whose result is 'Arg', and evaluate it to check if
   // it's an allowed result of a constant template argument.
   //
@@ -7341,7 +7368,8 @@ bool reflect_invoke(APValue &Result, ASTContext &C, MetaActions &Meta,
               makeReflection(
                   const_cast<ValueDecl *>(LVBase.get<const ValueDecl *>())));
 
-  return SetAndSucceed(Result, EvalResult.Val.Lift(CallExpr->getType()));
+  return SetAndSucceedWithLift(Result, Diagnoser, Range, EvalResult.Val,
+                               CallExpr->getType());
 }
 
 }  // end namespace clang

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -970,8 +970,13 @@ bool Metafunction::evaluate(APValue &Result, ASTContext &C,
 }
 
 bool Metafunction::Lookup(unsigned ID, const Metafunction *&result) {
-  if (ID >= NumMetafunctions)
+  // Always write the out-parameter: IDs reach this from deserialized ASTs, and
+  // a caller that forgets to check the return value must not be left holding
+  // whatever happened to be on the stack.
+  if (ID >= NumMetafunctions) {
+    result = nullptr;
     return true;
+  }
 
   result = &Metafunctions[ID];
   return false;

--- a/clang/lib/Parse/ParseReflect.cpp
+++ b/clang/lib/Parse/ParseReflect.cpp
@@ -208,19 +208,20 @@ bool Parser::ParseSpliceSpecifier(bool TryParseSpecialization) {
 
   SpliceResult SR;
   if (TryParseSpecialization && Tok.is(tok::less)) {
-    ASTTemplateArgsPtr TArgsPtr;
     SourceLocation LAngleLoc, RAngleLoc;
-    {
-      TemplateArgList TArgs;
-      if (ParseTemplateIdAfterTemplateName(/*ConsumeLastToken=*/false,
-                                           LAngleLoc, TArgs, RAngleLoc,
-                                           /*Template=*/nullptr))
-        return true;
 
-      TArgsPtr = ASTTemplateArgsPtr(TArgs.data(), TArgs.size());
-      end = Tok;
-      ConsumeToken();
-    }
+    // 'TArgs' must outlive the 'ASTTemplateArgsPtr' aliasing its storage, and
+    // therefore the call to 'ActOnSpliceSpecifier' which reads through it.
+    TemplateArgList TArgs;
+    if (ParseTemplateIdAfterTemplateName(/*ConsumeLastToken=*/false, LAngleLoc,
+                                         TArgs, RAngleLoc,
+                                         /*Template=*/nullptr))
+      return true;
+
+    ASTTemplateArgsPtr TArgsPtr(TArgs.data(), TArgs.size());
+    end = Tok;
+    ConsumeToken();
+
     SR = Actions.ActOnSpliceSpecifier(LSplice, Operand, RSplice, LAngleLoc,
                                       TArgsPtr, RAngleLoc);
   } else {

--- a/clang/lib/Sema/SemaReflect.cpp
+++ b/clang/lib/Sema/SemaReflect.cpp
@@ -1430,6 +1430,14 @@ ExprResult Sema::BuildCXXReflectExpr(SourceLocation OperatorLoc,
                                const_cast<ValueDecl *>(VD));
   }
 
+  // A 'std::meta::info' template argument is already a reflection; reflecting
+  // it again nests one level deeper, and the depth counter is finite.
+  if (!ER.Val.canLift()) {
+    Diag(E->getExprLoc(), diag::err_reflection_depth_exceeded)
+        << APValue::MaxReflectionDepth;
+    return ExprError();
+  }
+
   APValue RV = ER.Val.Lift(E->getType());
   return CXXReflectExpr::Create(Context, OperatorLoc, E->getSourceRange(), RV);
 }

--- a/clang/lib/Sema/SemaReflect.cpp
+++ b/clang/lib/Sema/SemaReflect.cpp
@@ -1169,20 +1169,24 @@ ExprResult Sema::ActOnCXXMetafunction(SourceLocation KwLoc,
   // Find or build a 'std::function' having a lambda with the 'Sema' object
   // (i.e., 'this') and the 'Metafunction' both captured. This will be provided
   // as a callback to evaluate the metafunction at constant evaluation time.
-  const auto &ImplIt = getMetafunctionCb(FnID);
+  const CXXMetafunctionExpr::ImplFn *Impl = getMetafunctionCb(FnID);
+  if (!Impl) {
+    Diag(FnIDArg->getExprLoc(), diag::err_unknown_metafunction);
+    return ExprError();
+  }
 
   // Return the CXXMetafunctionExpr representation.
   return BuildCXXMetafunctionExpr(KwLoc, LParenLoc, RParenLoc,
-                                  FnID, ImplIt, Args);
+                                  FnID, *Impl, Args);
 }
 
-const CXXMetafunctionExpr::ImplFn &Sema::getMetafunctionCb(unsigned FnID) {
+const CXXMetafunctionExpr::ImplFn *Sema::getMetafunctionCb(unsigned FnID) {
   auto ImplIt = MetafunctionImplCbs.find(FnID);
   if (ImplIt == MetafunctionImplCbs.end()) {
     const Metafunction *Metafn;
-    Metafunction::Lookup(FnID, Metafn);
+    if (Metafunction::Lookup(FnID, Metafn))
+      return nullptr;
 
-    assert(Metafn);
     auto MetafnImpl = std::make_unique<CXXMetafunctionExpr::ImplFn>(
         std::function(
             [this, Metafn](APValue &Result,
@@ -1199,7 +1203,7 @@ const CXXMetafunctionExpr::ImplFn &Sema::getMetafunctionCb(unsigned FnID) {
     ImplIt = MetafunctionImplCbs.try_emplace(FnID, std::move(MetafnImpl)).first;
   }
 
-  return *ImplIt->second;
+  return ImplIt->second.get();
 }
 
 SpliceResult Sema::ActOnSpliceSpecifier(SourceLocation LSpliceLoc,

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -9106,6 +9106,11 @@ TreeTransform<Derived>::TransformCXXReflectExpr(CXXReflectExpr *E) {
 template <typename Derived>
 ExprResult
 TreeTransform<Derived>::TransformCXXMetafunctionExpr(CXXMetafunctionExpr *E) {
+  // Deserializing a malformed AST file can leave an expression with no
+  // callback to carry over; the reader has already diagnosed the file.
+  if (!E->hasImpl())
+    return ExprError();
+
   SmallVector<Expr *, 2> Args(E->getNumArgs());
   for (unsigned I = 0; I < E->getNumArgs(); ++I) {
     ExprResult Arg = getDerived().TransformExpr(E->getArg(I));

--- a/clang/lib/Serialization/ASTReaderStmt.cpp
+++ b/clang/lib/Serialization/ASTReaderStmt.cpp
@@ -512,6 +512,9 @@ void ASTStmtReader::VisitCXXMetafunctionExpr(CXXMetafunctionExpr *E) {
   E->setLParenLoc(Record.readSourceLocation());
   E->setRParenLoc(Record.readSourceLocation());
   E->setMetaFnID(Record.readUInt32());
+  // Null when the ID names no metafunction; getMetafunctionCb has reported the
+  // file as malformed, and the expression is left without a callback rather
+  // than carrying a bogus one into constant evaluation.
   E->setImpl(Record.getMetafunctionCb(E->getMetaFnID()));
   E->setResultType(Record.readQualType());
 

--- a/clang/test/Reflection/splice-templates.cpp
+++ b/clang/test/Reflection/splice-templates.cpp
@@ -211,6 +211,44 @@ struct S {
 
 S<V> s;
 }  // namespace barry_example
+                             // ===================
+                             // large_argument_list
+                             // ===================
+
+// Splice-specializations whose argument list exceeds the inline capacity of the
+// parser's 'TemplateArgList' must keep that list alive across the call into
+// Sema; otherwise the arguments are read from freed storage.
+namespace large_argument_list {
+template <typename...> struct TCls { static constexpr int zero = 0; };
+template <int...> struct TValCls { static constexpr int zero = 0; };
+
+struct Outer { using type = int; };
+
+constexpr auto r = ^^TCls;
+
+static_assert(template [:r:]<int, int, int, int, int, int, int, int, int, int,
+                             int, int, int, int, int, int, int, int, int,
+                             int>::zero == 0);
+
+static_assert(template [:^^TValCls:]<0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+                                     13, 14, 15, 16, 17, 18, 19>::zero == 0);
+
+// Arguments carrying a nested-name-specifier own heap storage of their own.
+static_assert(template [:^^TCls:]<
+    Outer::type, Outer::type, Outer::type, Outer::type, Outer::type,
+    Outer::type, Outer::type, Outer::type, Outer::type, Outer::type,
+    Outer::type, Outer::type, Outer::type, Outer::type, Outer::type,
+    Outer::type, Outer::type, Outer::type, Outer::type,
+    Outer::type>::zero == 0);
+
+static_assert(is_same_v<typename [:r:]<int, int, int, int, int, int, int, int,
+                                       int, int, int, int, int, int, int, int,
+                                       int, int, int, int>,
+                        TCls<int, int, int, int, int, int, int, int, int, int,
+                             int, int, int, int, int, int, int, int, int,
+                             int>>);
+}  // namespace large_argument_list
+
                                  // ===========
                                  // error_cases
                                  // ===========

--- a/clang/unittests/AST/AttributeScratchpadTest.cpp
+++ b/clang/unittests/AST/AttributeScratchpadTest.cpp
@@ -1,0 +1,99 @@
+//===- unittests/AST/AttributeScratchpadTest.cpp --------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// The P3385 attribute reflection metafunctions synthesize ParsedAttr nodes and
+// keep them in a scratchpad owned by the ASTContext being evaluated. These
+// tests pin that ownership down: the scratchpad used to be a function-local
+// static shared by every ASTContext in the process, which raced in hosts that
+// build several ASTs concurrently (clangd) and grew without bound.
+//
+//===----------------------------------------------------------------------===//
+
+#include "../../lib/AST/AttributeScratchpad.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/Frontend/ASTUnit.h"
+#include "clang/Tooling/Tooling.h"
+#include "gtest/gtest.h"
+
+using namespace clang;
+
+namespace {
+
+/// Metafunction IDs, as spelled by the '__metafn_*' enumerators in
+/// libcxx/include/meta. They index the Metafunctions table in
+/// clang/lib/AST/ExprConstantMeta.cpp, so inserting a metafunction ahead of
+/// these shifts them; the tests below then fail to compile their input.
+constexpr unsigned MetafnGetIthAttributeOf = 115;
+constexpr unsigned MetafnIsAttribute = 116;
+
+const std::vector<std::string> ReflectionArgs = {
+    "-std=c++26", "-freflection", "-fattribute-reflection"};
+
+/// A translation unit that reaches toSyntacticForm(): reflecting on an
+/// attribute of a class forces the metafunction to rebuild a ParsedAttr from
+/// the semantic Attr, which is the only thing the scratchpad holds.
+std::string attributeReflectionCode() {
+  return R"cpp(
+    struct Sentinel {};
+    struct [[deprecated]] Widget {};
+    using info = decltype(^^int);
+    consteval info first_attribute_of_widget() {
+      return __metafunction()cpp" +
+         std::to_string(MetafnGetIthAttributeOf) + R"cpp(,
+                            ^^Widget, ^^Sentinel, 0);
+    }
+    constexpr info A = first_attribute_of_widget();
+    static_assert(__metafunction()cpp" +
+         std::to_string(MetafnIsAttribute) + R"cpp(, A));
+  )cpp";
+}
+
+std::unique_ptr<ASTUnit> buildAndCheck(const std::string &Code) {
+  std::unique_ptr<ASTUnit> AU =
+      tooling::buildASTFromCodeWithArgs(Code, ReflectionArgs);
+  if (AU && AU->getDiagnostics().hasErrorOccurred())
+    return nullptr;
+  return AU;
+}
+
+TEST(AttributeScratchpad, IsOwnedPerASTContext) {
+  std::unique_ptr<ASTUnit> First = buildAndCheck(attributeReflectionCode());
+  ASSERT_TRUE(First);
+  std::unique_ptr<ASTUnit> Second = buildAndCheck(attributeReflectionCode());
+  ASSERT_TRUE(Second);
+
+  AttributeScratchpad &FirstPad =
+      First->getASTContext().getAttributeScratchpad();
+  AttributeScratchpad &SecondPad =
+      Second->getASTContext().getAttributeScratchpad();
+
+  // Each context synthesized its own attribute, into its own scratchpad.
+  EXPECT_NE(&FirstPad, &SecondPad);
+  EXPECT_GT(FirstPad.pool.size(), 0u);
+
+  // Two identical translation units allocate the same number of attributes:
+  // the second does not inherit the first's.
+  EXPECT_EQ(FirstPad.pool.size(), SecondPad.pool.size());
+}
+
+TEST(AttributeScratchpad, DoesNotLeakIntoOtherASTContexts) {
+  // Keep the producing units alive, so that a scratchpad shared with them
+  // would still be holding their attributes.
+  std::unique_ptr<ASTUnit> Producer = buildAndCheck(attributeReflectionCode());
+  ASSERT_TRUE(Producer);
+  ASSERT_GT(Producer->getASTContext().getAttributeScratchpad().pool.size(), 0u);
+
+  std::unique_ptr<ASTUnit> Bystander = buildAndCheck("struct Unrelated {};");
+  ASSERT_TRUE(Bystander);
+
+  // A context that never evaluated an attribute reflection sees nothing.
+  EXPECT_EQ(Bystander->getASTContext().getAttributeScratchpad().pool.size(),
+            0u);
+}
+
+} // namespace

--- a/clang/unittests/AST/CMakeLists.txt
+++ b/clang/unittests/AST/CMakeLists.txt
@@ -14,6 +14,7 @@ add_clang_unittest(ASTTests
   ASTTypeTraitsTest.cpp
   ASTVectorTest.cpp
   AttrTest.cpp
+  AttributeScratchpadTest.cpp
   CommentLexer.cpp
   CommentParser.cpp
   CommentTextTest.cpp

--- a/clang/unittests/AST/CMakeLists.txt
+++ b/clang/unittests/AST/CMakeLists.txt
@@ -25,6 +25,7 @@ add_clang_unittest(ASTTests
   DeclTest.cpp
   EvaluateAsRValueTest.cpp
   ExternalASTSourceTest.cpp
+  MetafunctionLookupTest.cpp
   NamedDeclPrinterTest.cpp
   ProfilingTest.cpp
   RandstructTest.cpp

--- a/clang/unittests/AST/MetafunctionLookupTest.cpp
+++ b/clang/unittests/AST/MetafunctionLookupTest.cpp
@@ -1,0 +1,117 @@
+//===- unittests/AST/MetafunctionLookupTest.cpp ---------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// A CXXMetafunctionExpr carries a numeric metafunction ID that indexes the
+// Metafunctions table. When the expression is read back from a serialized AST
+// that ID arrives unvalidated, so Metafunction::Lookup and
+// Sema::getMetafunctionCb are the two places that decide whether an unknown ID
+// produces a usable callback. Lookup used to leave its out-parameter untouched
+// on failure and getMetafunctionCb used to ignore the failure return, so an
+// out-of-range ID left a stack-garbage Metafunction pointer captured in the
+// callback and called through at constant evaluation time.
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/AST/Metafunction.h"
+#include "clang/Frontend/ASTUnit.h"
+#include "clang/Sema/Sema.h"
+#include "clang/Tooling/Tooling.h"
+#include "gtest/gtest.h"
+
+using namespace clang;
+
+namespace {
+
+/// An ID far past the end of the Metafunctions table; the value the security
+/// report used as its example of what a crafted AST file would encode.
+constexpr unsigned OutOfRangeID = 0xFFFF;
+
+/// A recognisable non-null pointer to seed the out-parameter with. If Lookup
+/// fails without writing it, this is what a caller would be left holding --
+/// standing in for the uninitialized stack slot in the real defect.
+const Metafunction *const Sentinel =
+    reinterpret_cast<const Metafunction *>(static_cast<uintptr_t>(0xDEADBEEF));
+
+/// The number of entries in the Metafunctions table, discovered by asking
+/// Lookup. The table size is a file-local constant in ExprConstantMeta.cpp, so
+/// there is nothing to compare against directly.
+unsigned findTableSize() {
+  for (unsigned ID = 0; ID < OutOfRangeID; ++ID) {
+    const Metafunction *Metafn = Sentinel;
+    if (Metafunction::Lookup(ID, Metafn))
+      return ID;
+  }
+  return OutOfRangeID;
+}
+
+TEST(MetafunctionLookup, OutOfRangeIDNullsOutParameter) {
+  const Metafunction *Metafn = Sentinel;
+
+  EXPECT_TRUE(Metafunction::Lookup(OutOfRangeID, Metafn));
+  EXPECT_EQ(nullptr, Metafn);
+}
+
+TEST(MetafunctionLookup, FailsExactlyPastTheEndOfTheTable) {
+  unsigned Size = findTableSize();
+  ASSERT_GT(Size, 0u);
+  ASSERT_LT(Size, OutOfRangeID);
+
+  // The last valid ID still resolves...
+  const Metafunction *Last = Sentinel;
+  EXPECT_FALSE(Metafunction::Lookup(Size - 1, Last));
+  EXPECT_NE(nullptr, Last);
+  EXPECT_NE(Sentinel, Last);
+
+  // ...and the first invalid one fails with the out-parameter cleared, rather
+  // than leaving the caller's pointer as it found it.
+  const Metafunction *Past = Sentinel;
+  EXPECT_TRUE(Metafunction::Lookup(Size, Past));
+  EXPECT_EQ(nullptr, Past);
+}
+
+/// The smallest translation unit that gets a Sema with reflection enabled. No
+/// metafunction is used: getMetafunctionCb is asked for IDs directly.
+std::unique_ptr<ASTUnit> buildReflectionAST() {
+  std::unique_ptr<ASTUnit> AU = tooling::buildASTFromCodeWithArgs(
+      "using info = decltype(^^int);\n",
+      {"-std=c++26", "-freflection"});
+  if (AU && AU->getDiagnostics().hasErrorOccurred())
+    return nullptr;
+  return AU;
+}
+
+TEST(MetafunctionLookup, OutOfRangeIDYieldsNoCallback) {
+  std::unique_ptr<ASTUnit> AU = buildReflectionAST();
+  ASSERT_TRUE(AU);
+  ASSERT_TRUE(AU->hasSema());
+  Sema &S = AU->getSema();
+
+  // This is the call ASTStmtReader::VisitCXXMetafunctionExpr makes with an ID
+  // taken verbatim from the AST file.
+  EXPECT_EQ(nullptr, S.getMetafunctionCb(OutOfRangeID));
+  EXPECT_EQ(nullptr, S.getMetafunctionCb(findTableSize()));
+}
+
+TEST(MetafunctionLookup, InRangeIDYieldsCallableCallback) {
+  std::unique_ptr<ASTUnit> AU = buildReflectionAST();
+  ASSERT_TRUE(AU);
+  ASSERT_TRUE(AU->hasSema());
+  Sema &S = AU->getSema();
+
+  // Guards against the previous test passing because getMetafunctionCb returns
+  // null for everything.
+  const CXXMetafunctionExpr::ImplFn *Impl = S.getMetafunctionCb(0);
+  ASSERT_NE(nullptr, Impl);
+  EXPECT_TRUE(static_cast<bool>(*Impl));
+
+  // Repeated requests are memoized against one stable callback object; the
+  // expression stores an unowned pointer to it.
+  EXPECT_EQ(Impl, S.getMetafunctionCb(0));
+}
+
+} // namespace

--- a/libcxx/test/std/experimental/reflection/reflection-depth.verify.cpp
+++ b/libcxx/test/std/experimental/reflection/reflection-depth.verify.cpp
@@ -1,0 +1,61 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright 2024 Bloomberg Finance L.P.
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03 || c++11 || c++14 || c++17 || c++20
+// ADDITIONAL_COMPILE_FLAGS: -freflection
+
+// <experimental/reflection>
+//
+// [reflection]
+
+#include <meta>
+
+
+                            // ===================
+                            // nested_reflect_test
+                            // ===================
+
+// 'std::meta::info' is a structural type, so 'reflect_constant' accepts one and
+// returns a reflection of it. The representation counts these nestings in a
+// fixed-width field; the count must saturate into a diagnostic rather than wrap
+// back to "not a reflection".
+
+namespace nested_reflect_test {
+
+// Returns a reflection nested 'N' levels deep over the integer 0.
+consteval std::meta::info nest(int N) {
+  std::meta::info R = std::meta::reflect_constant(0);
+  for (int Idx = 1; Idx < N; ++Idx)
+    R = std::meta::reflect_constant(R);
+      // expected-note@-1 {{reflection would nest more than 255 levels deep}}
+  return R;
+}
+
+// The deepest representable nesting is still a reflection of a value.
+static_assert(std::meta::is_value(nest(255)));
+
+// Peeling exactly 254 layers back off must land on the reflection of the
+// original integer: one layer too few or too many fails to extract. This pins
+// the depth of 'nest(255)' at 255, so the cap below is at the representable
+// limit and not somewhere short of it.
+consteval int unnest_255(std::meta::info R) {
+  for (int Idx = 1; Idx < 255; ++Idx)
+    R = std::meta::extract<std::meta::info>(R);
+  return std::meta::extract<int>(R);
+}
+static_assert(unnest_255(nest(255)) == 0);
+
+// One level further is refused.
+constexpr auto too_deep = nest(256);
+  // expected-error@-1 {{must be initialized by a constant expression}}
+
+}  // namespace nested_reflect_test
+
+int main() { }

--- a/libcxx/test/std/experimental/reflection/template-arguments.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/template-arguments.pass.cpp
@@ -307,6 +307,30 @@ int p[2];
 static_assert(template_arguments_of(^^fn<p[1]>)[0] ==
               std::meta::reflect_object(p[1]));
 
+// An array index in an lvalue path is a raw integer, not a tagged pointer:
+// indices large enough to survive masking off the low bits of a 'Decl *' must
+// not be decoded as declarations.
+int big[64];
+struct Base { int b; };
+struct Derived : Base { int arr[64]; };
+Derived d;
+
+template <const int *> struct PtrCls {};
+template <int &> struct RefCls {};
+
+static_assert(template_arguments_of(^^fn<big[40]>)[0] ==
+              std::meta::reflect_object(big[40]));
+static_assert(type_of(template_arguments_of(^^fn<big[40]>)[0]) == ^^int);
+
+static_assert(type_of(template_arguments_of(^^PtrCls<&big[40]>)[0]) ==
+              ^^const int *);
+
+// The same, reached through a base-class and member path before the index.
+static_assert(template_arguments_of(^^fn<d.arr[33]>)[0] ==
+              std::meta::reflect_object(d.arr[33]));
+static_assert(type_of(template_arguments_of(^^RefCls<d.arr[33]>)[0]) == ^^int);
+static_assert(type_of(template_arguments_of(^^RefCls<d.b>)[0]) == ^^int);
+
 }  // namespace subobject_reflection_arguments
 
                    // =======================================

--- a/libcxx/test/std/experimental/reflection/to-and-from-values.pass.cpp
+++ b/libcxx/test/std/experimental/reflection/to-and-from-values.pass.cpp
@@ -409,6 +409,46 @@ static_assert(rp != rv);
 static_assert(ro != rv);
 }  // namespace pointer_object_ambiguity
 
+                        // ==========================
+                        // array_subobject_lvalue_path
+                        // ==========================
+
+namespace array_subobject_lvalue_path {
+
+// The type of an object reflection is computed by walking the lvalue path of
+// the underlying value. Entries are untagged: an entry is a declaration only
+// when the type it applies to is a class type, and a raw index otherwise.
+// Indices below 8 are masked to a null 'Decl *' and so never exercised this;
+// larger ones must not be decoded as declarations either.
+constexpr int arr[64] = {};
+
+struct Base { int b; };
+struct Derived : Base { int arr[64]; };
+constexpr Derived d = {};
+
+constexpr auto ro = std::meta::reflect_object(arr[40]);
+static_assert(is_object(ro));
+static_assert(type_of(ro) == ^^const int);
+static_assert([:ro:] == 0);
+
+constexpr auto rc = std::meta::reflect_constant(&arr[40]);
+static_assert(is_value(rc));
+static_assert(type_of(rc) == ^^const int *);
+static_assert([:rc:] == &arr[40]);
+
+// A base-class entry, then a member entry, then an array index.
+constexpr auto rn = std::meta::reflect_object(d.arr[33]);
+static_assert(type_of(rn) == ^^const int);
+static_assert([:rn:] == 0);
+
+constexpr auto rb = std::meta::reflect_object(d.b);
+static_assert(type_of(rb) == ^^const int);
+
+static_assert(constant_of(ro) == std::meta::reflect_constant(0));
+static_assert(constant_of(rn) == std::meta::reflect_constant(0));
+
+}  // namespace array_subobject_lvalue_path
+
                       // ================================
                       // reflect_constants_of_class_types
                       // ================================


### PR DESCRIPTION
A couple of (coding) bugs to be fixed will see remediation here ~
- [Discriminate array-index lvalue path entries instead of dereferencing…](https://github.com/bloomberg/clang-p2996/pull/343/commits/b6f2f3ac906c8357f8cbba7ea982a9ccba8a5b98)
- [Fix Hoist splice-specialization template argument list out of scope](https://github.com/bloomberg/clang-p2996/pull/343/commits/15c071b49eeaa9044fa82fe2e8282a2b983e4a7a)
- [Diagnose reflections nested past the depth counter instead of wrappin…](https://github.com/bloomberg/clang-p2996/pull/343/commits/585915eef53f13298ffb1eee0bb707e85146800c)
- [Own the attribute reflection scratchpad per ASTContext instead of glo…](https://github.com/bloomberg/clang-p2996/pull/343/commits/b922a9ff18e728c2efc95d3127db72727fd50c9f)
- [Reject out-of-range metafunction IDs instead of calling through stack…](https://github.com/bloomberg/clang-p2996/pull/343/commits/de4b569360894c113e5306c42977025f5b6a9972)