### PR TITLE
Allow reflections of values designating immediate functions

### DIFF
--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -781,10 +781,16 @@ public:
   ///
   /// If 'Kind' is 'PlainlyConstantEvaluated', then 'ContainingDecl' is the
   /// declaration containing the expression and must be non-null.
+  ///
+  /// If 'AllowImmediateFunctions' is true, the result may contain pointers or
+  /// references to immediate functions. This is used when representing a value
+  /// as a reflection (P2996), where the value is held by a consteval-only type
+  /// and so can never reach a runtime context.
   bool EvaluateAsConstantExpr(
       EvalResult &Result, const ASTContext &Ctx,
       ConstantExprKind Kind = ConstantExprKind::Normal,
-      Decl *ContainingDecl = nullptr) const;
+      Decl *ContainingDecl = nullptr,
+      bool AllowImmediateFunctions = false) const;
 
   /// If the current Expr is a pointer, this will try to statically
   /// determine the number of bytes available where the pointer is pointing.

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -1001,6 +1001,12 @@ namespace {
     /// function context later.
     bool IsImmediateEscalating = false;
 
+    /// Whether the value being checked is destined for a reflection (P2996).
+    /// If so, permit pointers and references to immediate functions: the
+    /// result is held by a 'std::meta::info', which is a consteval-only type
+    /// and therefore can never carry the pointer into a runtime context.
+    bool AllowImmediateFunctions = false;
+
     enum EvaluationMode {
       /// Evaluate as a constant expression. Stop if we find that the expression
       /// is not a constant expression.
@@ -2409,7 +2415,7 @@ static bool CheckLValueConstantExpression(EvalInfo &Info, SourceLocation Loc,
   }
 
   if (auto *FD = dyn_cast_or_null<FunctionDecl>(BaseVD);
-      FD && FD->isImmediateFunction()) {
+      FD && FD->isImmediateFunction() && !Info.AllowImmediateFunctions) {
     Info.FFDiag(Loc, diag::note_consteval_address_accessible)
         << !Type->isAnyPointerType();
     Info.Note(FD->getLocation(), diag::note_declared_at);
@@ -2567,7 +2573,7 @@ static bool CheckMemberPointerConstantExpression(EvalInfo &Info,
   const auto *FD = dyn_cast_or_null<CXXMethodDecl>(Member);
   if (!FD)
     return true;
-  if (FD->isImmediateFunction()) {
+  if (FD->isImmediateFunction() && !Info.AllowImmediateFunctions) {
     Info.FFDiag(Loc, diag::note_consteval_address_accessible) << /*pointer*/ 0;
     Info.Note(FD->getLocation(), diag::note_declared_at);
     return false;
@@ -8862,7 +8868,12 @@ bool ExprEvaluatorBase<Derived>::VisitCXXMetafunctionExpr(
           return false;
       }
 
-      // Check this core constant expression is a constant expression.
+      // Check this core constant expression is a constant expression. A
+      // metafunction argument only ever feeds a reflection, so a pointer or
+      // reference to an immediate function is fine here (see
+      // EvalInfo::AllowImmediateFunctions).
+      llvm::SaveAndRestore<bool> AllowImmediate(Info.AllowImmediateFunctions,
+                                                true);
       return CheckConstantExpression(Info, E->getExprLoc(), E->getType(),
                                      Result, ConstantExprKind::Normal);
     }
@@ -17306,8 +17317,8 @@ static bool EvaluateDestruction(const ASTContext &Ctx, APValue::LValueBase Base,
 }
 
 bool Expr::EvaluateAsConstantExpr(EvalResult &Result, const ASTContext &Ctx,
-                                  ConstantExprKind Kind,
-                                  Decl *ContainingDecl) const {
+                                  ConstantExprKind Kind, Decl *ContainingDecl,
+                                  bool AllowImmediateFunctions) const {
   assert(!isValueDependent() &&
          "Expression evaluator can't be called on a dependent expression.");
   bool IsConst;
@@ -17327,6 +17338,7 @@ bool Expr::EvaluateAsConstantExpr(EvalResult &Result, const ASTContext &Ctx,
   Info.InConstantContext = true;
   Info.IsImmediateEscalating =
       (Kind == ConstantExprKind::EscalatoryImmediateInvocation);
+  Info.AllowImmediateFunctions = AllowImmediateFunctions;
 
   if (Info.EnableNewConstInterp) {
     if (!Info.Ctx.getInterpContext().evaluate(Info, this, Result.Val, Kind))

--- a/clang/lib/AST/ExprConstantMeta.cpp
+++ b/clang/lib/AST/ExprConstantMeta.cpp
@@ -5661,7 +5661,12 @@ bool reflect_result(APValue &Result, ASTContext &C, MetaActions &Meta,
     ConstantExprKind CEKind = (OVE->getType()->isRecordType() && !IsLValue) ?
                               ConstantExprKind::ClassTemplateArgument :
                               ConstantExprKind::NonClassTemplateArgument;
-    if (!OVE->EvaluateAsConstantExpr(Discarded, C, CEKind))
+    // The value is being stored in a reflection, so unlike a real template
+    // argument it may designate an immediate function: 'std::meta::info' is a
+    // consteval-only type, so the value cannot escape to a runtime context.
+    if (!OVE->EvaluateAsConstantExpr(Discarded, C, CEKind,
+                                     /*ContainingDecl=*/nullptr,
+                                     /*AllowImmediateFunctions=*/true))
       return Diagnoser(Range.getBegin(), diag::metafn_result_not_representable)
           << (IsLValue ? 1 : 0) << Range;
   }

--- a/clang/lib/Sema/SemaReflect.cpp
+++ b/clang/lib/Sema/SemaReflect.cpp
@@ -1694,6 +1694,63 @@ static ValueDecl *normalizeSplicedMemberDecl(ValueDecl *VD) {
   return VD;
 }
 
+/// Finds an immediate function designated by a pointer or pointer-to-member
+/// subobject of \p V, if there is one.
+///
+/// A reflection may hold a value that designates an immediate function (e.g.
+/// 'std::meta::reflect_constant(&some_consteval_fn)'), since 'std::meta::info'
+/// is a consteval-only type. Splicing such a value outside of an immediate
+/// invocation would let the address reach a runtime context, so the splice has
+/// to be rejected there.
+static const FunctionDecl *findImmediateFunction(const APValue &V) {
+  switch (V.getKind()) {
+  case APValue::LValue:
+    if (const auto *VD = V.getLValueBase().dyn_cast<const ValueDecl *>()) {
+      if (const auto *FD = dyn_cast<FunctionDecl>(VD);
+          FD && FD->isImmediateFunction())
+        return FD;
+      // A class-type value is materialized as a template parameter object, so
+      // look through one for a pointer it may be holding.
+      if (const auto *TPO = dyn_cast<TemplateParamObjectDecl>(VD))
+        return findImmediateFunction(TPO->getValue());
+    }
+    return nullptr;
+  case APValue::MemberPointer:
+    if (const auto *FD =
+            dyn_cast_or_null<FunctionDecl>(V.getMemberPointerDecl());
+        FD && FD->isImmediateFunction())
+      return FD;
+    return nullptr;
+  case APValue::Struct:
+    for (unsigned I = 0, N = V.getStructNumBases(); I != N; ++I)
+      if (const FunctionDecl *FD = findImmediateFunction(V.getStructBase(I)))
+        return FD;
+    for (unsigned I = 0, N = V.getStructNumFields(); I != N; ++I)
+      if (const FunctionDecl *FD = findImmediateFunction(V.getStructField(I)))
+        return FD;
+    return nullptr;
+  case APValue::Union:
+    if (V.getUnionField())
+      return findImmediateFunction(V.getUnionValue());
+    return nullptr;
+  case APValue::Array:
+    for (unsigned I = 0, N = V.getArrayInitializedElts(); I != N; ++I)
+      if (const FunctionDecl *FD =
+              findImmediateFunction(V.getArrayInitializedElt(I)))
+        return FD;
+    if (V.hasArrayFiller())
+      return findImmediateFunction(V.getArrayFiller());
+    return nullptr;
+  case APValue::Vector:
+    for (unsigned I = 0, N = V.getVectorLength(); I != N; ++I)
+      if (const FunctionDecl *FD = findImmediateFunction(V.getVectorElt(I)))
+        return FD;
+    return nullptr;
+  default:
+    return nullptr;
+  }
+}
+
 ExprResult Sema::BuildReflectionSpliceExpr(SourceLocation TemplateKWLoc,
                                            SpliceSpecifier *Splice,
                                            bool AllowMemberReference) {
@@ -1721,6 +1778,24 @@ ExprResult Sema::BuildReflectionSpliceExpr(SourceLocation TemplateKWLoc,
       Diag(Splice->getBeginLoc(),
            diag::err_unexpected_reflection_kind_in_splice) << 3;
       return ExprError();
+    }
+
+    // A reflected value or object may designate an immediate function; mirror
+    // the check that MarkDeclRefReferenced applies to a naked reference to one,
+    // since no DeclRefExpr is formed here for that machinery to see.
+    if (bool IsValue = Refl.getReflectionKind() == ReflectionKind::Value;
+        (IsValue || Refl.getReflectionKind() == ReflectionKind::Object) &&
+        !isUnevaluatedContext() && !isConstantEvaluatedContext() &&
+        !isImmediateFunctionContext() &&
+        !isCheckingDefaultArgumentOrInitializer() &&
+        !RebuildingImmediateInvocation) {
+      if (const FunctionDecl *FD = findImmediateFunction(
+              IsValue ? Refl.getReflectedValue() : Refl.getReflectedObject())) {
+        Diag(Splice->getBeginLoc(), diag::err_invalid_consteval_take_address)
+            << FD << /*call operator of=*/false << FD->isConsteval();
+        Diag(FD->getLocation(), diag::note_declared_at);
+        return ExprError();
+      }
     }
 
     Expr *Result = nullptr;


### PR DESCRIPTION
This fixes https://github.com/bloomberg/clang-p2996/issues/332:
std::meta::reflect_constant(&some_consteval_fn) was rejected: the constant-expression check that forbids pointers and references to immediate functions fired while evaluating the metafunction argument. That check exists to stop the address of a consteval function reaching a runtime context, but a value held by a std::meta::info cannot - std::meta::info is a consteval-only type.

Add an AllowImmediateFunctions flag to EvalInfo, plumbed through Expr::EvaluateAsConstantExpr, and set it when evaluating a metafunction argument and when computing a reflect_result value. With it set, CheckLValueConstantExpression and CheckMemberPointerConstantExpression no longer reject an immediate function.

Deferring the check to evaluation means the splice has to enforce it instead, since no DeclRefExpr is formed for MarkDeclRefReferenced to see. BuildReflectionSpliceExpr now walks the reflected value or object for a pointer or pointer-to-member designating an immediate function, looking through template parameter objects and aggregate subobjects, and diagnoses one outside an immediate or constant-evaluated context.

*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
A clear and concise description of the changes you have made.

**Testing performed**
Describe the testing you have performed to ensure that the bug has been addressed, or that the new feature works as planned.

**Additional context**
Add any other context about your contribution here.
