### PR TITLE
Remove warning if `&` is not directly in code.

### DIFF
--- a/clang/lib/Parse/ParseReflect.cpp
+++ b/clang/lib/Parse/ParseReflect.cpp
@@ -128,9 +128,9 @@ ExprResult Parser::ParseCXXReflectExpression(SourceLocation OpLoc) {
 
     std::string refKind;
     if (QualType QT = cast<LocInfoType>(TR.get().get())->getType();
-        QT->isLValueReferenceType()) {
+        isa<LValueReferenceType>(QT)) {
       refKind = "&";
-    } else if (QT->isRValueReferenceType()) {
+    } else if (isa<RValueReferenceType>(QT)) {
       refKind = "&&";
     } else if (auto *FPT = dyn_cast<FunctionProtoType>(QT)) {
       if (FPT->getRefQualifier() == RQ_LValue)


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #346*